### PR TITLE
Hotfix/build artifact default

### DIFF
--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -15,7 +15,7 @@ class ArtifactBuilder:
 
     def setup(self, builder):
         path = builder.configuration.input_data.artifact_path
-        append = builder.configuration.input_data.append
+        append = builder.configuration.input_data.append_to_artifact
         hdf.touch(path, append)
 
         self.artifact = Artifact(path)

--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -15,8 +15,8 @@ class ArtifactBuilder:
 
     def setup(self, builder):
         path = builder.configuration.input_data.artifact_path
-        append = builder.configuration.input_data.append_to_artifact
-        hdf.touch(path, append)
+        overwrite = builder.configuration.input_data.overwrite
+        hdf.touch(path, overwrite)
 
         self.artifact = Artifact(path)
         self.location = builder.configuration.input_data.location

--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -15,8 +15,8 @@ class ArtifactBuilder:
 
     def setup(self, builder):
         path = builder.configuration.input_data.artifact_path
-        overwrite = builder.configuration.input_data.overwrite
-        hdf.touch(path, overwrite)
+        append = builder.configuration.input_data.append
+        hdf.touch(path, append)
 
         self.artifact = Artifact(path)
         self.location = builder.configuration.input_data.location

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -19,7 +19,7 @@ from vivarium.config_tree import ConfigTree
                 readable=True))
 @click.argument('locations', nargs=-1)
 @click.option('--project', default='proj_cost_effect')
-@click.option('--output_root', type=click.Path(file_okay=False, writable=True),
+@click.option('--output-root', type=click.Path(file_okay=False, writable=True),
               help="Directory to save artifact result in")
 @click.option('--append', type=click.BOOL, default=False,
               help="Preserve existing artifact and append to it")
@@ -130,7 +130,7 @@ def _build_artifact():
     parser = argparse.ArgumentParser()
     parser.add_argument('model_specification', type=str,
                         help="path to a model_specification file")
-    parser.add_argument('--output_root', type=str, required=False,
+    parser.add_argument('--output-root', type=str, required=False,
                         help="directory to save artifact to. "
                              "Overwrites model_specification file")
     parser.add_argument('--location', type=str, required=False,

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -17,13 +17,14 @@ from vivarium.config_tree import ConfigTree
 @click.command()
 @click.argument('model_specification', type=click.Path(dir_okay=False,
                 readable=True))
-@click.argument('project')
 @click.argument('locations', nargs=-1)
+@click.option('--project', default='proj_cost_effect')
 @click.option('--output_root', type=click.Path(file_okay=False, writable=True),
               help="Directory to save artifact result in")
 @click.option('--from_scratch', type=click.BOOL, default=True,
               help="Do not reuse any data in the artifact, if any exists")
 def build_artifact(model_specification, project, locations,
+def build_artifact(model_specification, locations, project,
                    output_root, from_scratch):
     """
     build_artifact is a program for building data artifacts from a

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -175,7 +175,7 @@ def main(model_specification_file, output_root, location, append):
     simulation_config.input_data.location = get_location(location, simulation_config)
     simulation_config.input_data.artifact_path = get_output_path(model_specification_file,
                                                                  output_root, location)
-    simulation_config.input_data.append = append
+    simulation_config.input_data.append_to_artifact = append
 
     plugin_manager = PluginManager(plugin_config)
     component_config_parser = plugin_manager.get_plugin('component_configuration_parser')

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -33,7 +33,7 @@ def build_artifact(model_specification, project, locations,
 
     Any artifact.path specified in the configuration file is guaranteed to
     be overwritten either by the optional output_root or a predetermined path
-    based on user: /ihme/scratch/{user}/vivarium_artifacts
+    based on user: /ihme/scratch/users/{user}/vivarium_artifacts
     """
 
     config_path = pathlib.Path(model_specification).resolve()

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -18,10 +18,13 @@ from vivarium.config_tree import ConfigTree
 @click.argument('model_specification', type=click.Path(dir_okay=False,
                 readable=True))
 @click.argument('locations', nargs=-1)
-@click.option('--project', default='proj_cost_effect')
-@click.option('--output-root', type=click.Path(file_okay=False, writable=True),
-              help="Directory to save artifact result in")
-@click.option('--append', type=click.BOOL, default=False,
+@click.option('--project', '-P', default='proj_cost_effect',
+              help='Cluster project under which the job will '
+                   'be submitted. Defaults to proj_cost_effect')
+@click.option('--output-root', '-o', type=click.Path(file_okay=False, writable=True),
+              help="Directory to save artifact to. "
+                   "Overwrites model specification file")
+@click.option('--append', '-a', type=click.BOOL, default=False,
               help="Preserve existing artifact and append to it")
 def build_artifact(model_specification, locations, project,
                    output_root, append):
@@ -130,14 +133,14 @@ def _build_artifact():
     parser = argparse.ArgumentParser()
     parser.add_argument('model_specification', type=str,
                         help="path to a model_specification file")
-    parser.add_argument('--output-root', type=str, required=False,
+    parser.add_argument('--output-root', '-o', type=str, required=False,
                         help="directory to save artifact to. "
                              "Overwrites model_specification file")
     parser.add_argument('--location', type=str, required=False,
                         help="location to get data for. "
                              "Overwrites model_specification file")
-    parser.add_argument('--append', action="store_true",
-                        help="Append to an artifact if it exists")
+    parser.add_argument('--append', '-a', action="store_true",
+                        help="Preserve existing artifact and append to it")
     parser.add_argument('--verbose', '-v', action='store_true')
     parser.add_argument('--pdb', action='store_true')
     args = parser.parse_args()


### PR DESCRIPTION
Some logic was flipped around a bit, it became apparent when i tried to build some artifacts. Specifying a path where there was no data, i.e. I want to make a new artifact, resulted in an error unless --from-scratch was included. 

The original argument was from-scratch and seemed intended to indicate the user wanted to overwrite data, but it was saved into a config slot that was for appending, and what hdf's touch method did with it didn't really follow what the argument meant. Additionally, I misinterpreted what store_true did as a default. 

Additionally there is now a default cluster project set, proj_cost_effect.

Originally there was more here, but now it is mostly a name change. There is a corresponding PR to vivarium_public_health for hdf's touch method which interprets the append configuration a bit more.