### PR TITLE
Bugfix/artifact builder filters

### DIFF
--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -422,7 +422,7 @@ def _get_relative_risk(entities, location_ids):
         measure_data.loc[:, draw_cols] = 1/measure_data.loc[:, draw_cols]
         measure_data = _handle_coverage_gap_data(entities, measure_data, 1)
 
-    cause_ids = [causes.__getitem__(c).gbd_id for c in causes.__slots__]
+    cause_ids = [c.gbd_id for c in causes]
     valid_cause_ids = [c for c in measure_data['cause_id'].unique() if c in cause_ids]
     measure_data = measure_data[measure_data['cause_id'].isin(valid_cause_ids)]
 

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -422,9 +422,8 @@ def _get_relative_risk(entities, location_ids):
         measure_data.loc[:, draw_cols] = 1/measure_data.loc[:, draw_cols]
         measure_data = _handle_coverage_gap_data(entities, measure_data, 1)
 
-    cause_ids = [c.gbd_id for c in causes]
-    valid_cause_ids = [c for c in measure_data['cause_id'].unique() if c in cause_ids]
-    measure_data = measure_data[measure_data['cause_id'].isin(valid_cause_ids)]
+    most_detailed_causes = measure_data['cause_id'].isin([c.gbd_id for c in causes])
+    measure_data = measure_data[most_detailed_causes]
 
     # FIXME: I'm passing because this is broken for zinc_deficiency, and I don't have time to investigate -J.C.
     # err_msg = ("Not all relative risk data has both the 'mortality' and 'morbidity' flag "

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -255,6 +255,11 @@ def _validate_data(data: pd.DataFrame, key_columns: Iterable[str]=None):
         raise DuplicateDataError()
 
 
+def _get_cause_ids():
+    causes_list = [causes.__getitem__(c) for c in causes.__slots__]
+    ids = [c.gbd_id for c in causes_list if c is not None]
+    return ids
+
 #####################
 # get_draws helpers #
 #####################
@@ -422,6 +427,9 @@ def _get_relative_risk(entities, location_ids):
         draw_cols = [f'draw_{i}' for i in range(1000)]
         measure_data.loc[:, draw_cols] = 1/measure_data.loc[:, draw_cols]
         measure_data = _handle_coverage_gap_data(entities, measure_data, 1)
+
+    valid_cause_ids = [c for c in measure_data['cause_id'].unique() if c in _get_cause_ids()]
+    measure_data = measure_data[measure_data['cause_id'].isin(valid_cause_ids)]
 
     # FIXME: I'm passing because this is broken for zinc_deficiency, and I don't have time to investigate -J.C.
     # err_msg = ("Not all relative risk data has both the 'mortality' and 'morbidity' flag "

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -254,12 +254,6 @@ def _validate_data(data: pd.DataFrame, key_columns: Iterable[str]=None):
     if key_columns and np.any(data.duplicated(key_columns)):
         raise DuplicateDataError()
 
-
-def _get_cause_ids():
-    causes_list = [causes.__getitem__(c) for c in causes.__slots__]
-    ids = [c.gbd_id for c in causes_list if c is not None]
-    return ids
-
 #####################
 # get_draws helpers #
 #####################
@@ -428,7 +422,8 @@ def _get_relative_risk(entities, location_ids):
         measure_data.loc[:, draw_cols] = 1/measure_data.loc[:, draw_cols]
         measure_data = _handle_coverage_gap_data(entities, measure_data, 1)
 
-    valid_cause_ids = [c for c in measure_data['cause_id'].unique() if c in _get_cause_ids()]
+    cause_ids = [causes.__getitem__(c).gbd_id for c in causes.__slots__]
+    valid_cause_ids = [c for c in measure_data['cause_id'].unique() if c in cause_ids]
     measure_data = measure_data[measure_data['cause_id'].isin(valid_cause_ids)]
 
     # FIXME: I'm passing because this is broken for zinc_deficiency, and I don't have time to investigate -J.C.

--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -18,10 +18,10 @@ class ArtifactBuilder:
         path = builder.configuration.input_data.artifact_path
         append = builder.configuration.input_data.append_to_artifact
         hdf.touch(path, append)
+        draw = builder.configuration.input_data.input_draw_number
 
         self.location = builder.configuration.input_data.location
-        self.draw = builder.configuration.input_data.input_draw_number
-        self.artifact = Artifact(path, filter_terms=[f'draw == {self.draw}', get_location_term(self.location)])
+        self.artifact = Artifact(path, filter_terms=[f'draw == {draw}', get_location_term(self.location)])
         self.modeled_causes = builder.components.get_components(DiseaseModel)
         self.processed_entities = set()
         self.start_time = datetime.now()


### PR DESCRIPTION
This is a quick fix for `ArtifactBuilder` which misses filter terms(draw and location) and fails in building an artifact during the setup phase. ( basically, I added the filter terms symmetrical to the `ArtifactManager` in vivarium_public_health. With this fix, users should be able to build an artifact as expected. 