### PR TITLE
add a missing dependency to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,6 @@ deps=pytest
      -rrequirements.txt
 commands=
     pip install Cython
+    pip install hypothesis
     pip install --process-dependency-links -e .[gbd_access]
     py.test


### PR DESCRIPTION
This is a tiny PR, just adding a pip install so tox will run