### PR TITLE
Bugfix/artifact builder not properly get modeled causes

### DIFF
--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -219,14 +219,14 @@ def _get_additional_id_columns(data, entities):
         Covariate: 'covariate_id',
         Risk: 'risk_id',
         Etiology: 'etiology_id',
-        CoverageGap: 'coverage_gap_id',
+        CoverageGap: 'coverage_gap',
         HealthcareEntity: 'healthcare_entity',
         HealthTechnology: 'health_technology',
     }
     out = set()
     out.add(id_column_map[type(entities[0])])
-    if isinstance(entities[0], CoverageGap) and data['measure'].all() in ['relative_risk', 'population_attributable_fraction']:
-        out.add('rei_id')
+    if isinstance(entities[0], CoverageGap) and data['measure'].all() in ['relative_risk']:
+        out.add('risk_id')
     out |= set(data.columns) & set(id_column_map.values())
     return out
 
@@ -471,6 +471,7 @@ def _get_relative_risk(entities: Iterable[Union[Risk, CoverageGap]], location_id
             draw_cols = [f'draw_{i}' for i in range(1000)]
             measure_data.loc[:, draw_cols] = 1 / measure_data.loc[:, draw_cols]
             measure_data = _handle_special_coverage_gap_data(special_cases, measure_data, 1)
+            measure_data = measure_data.rename(columns={"rei_id": "risk_id"})
             df.append(measure_data)
 
         # any coverage_gap from aux_data
@@ -485,7 +486,8 @@ def _get_relative_risk(entities: Iterable[Union[Risk, CoverageGap]], location_id
                     data['year_id'] = id
                     missing_data = missing_data.append(data)
                 measure_data = pd.concat([measure_data] + missing_data)
-                measure_data['coverage_gap_id'] = np.NaN
+                measure_data['coverage_gap'] = entity.name
+                measure_data = measure_data.rename(columns={"rei_id": "risk_id"})
                 del measure_data['measure']
                 df.append(measure_data)
         measure_data = pd.concat(df)
@@ -525,7 +527,7 @@ def _compute_paf_for_special_cases(affected_entity: Union[Cause, Risk], entity: 
             rr = rr[(rr.cause_id == cause_id)]
         elif isinstance(affected_entity, Risk):
             risk_id, cause_id = affected_entity.gbd_id, np.nan
-            rr = rr[(rr.rei_id == risk_id)]
+            rr = rr[(rr.risk_id == risk_id)]
         else:
             raise InvalidQueryError(f'You requested the non-valid PAF data for {entity}-{affected_entity} pair')
 
@@ -547,12 +549,14 @@ def _compute_paf_for_special_cases(affected_entity: Union[Cause, Risk], entity: 
         temp_result['location_id'] = location_id
         temp_result['risk_id'] = risk_id
         temp_result['measure_id'] = 3
+        if isinstance(entity, CoverageGap):
+            temp_result['coverage_gap'] = entity.name
         paf.append(temp_result.reset_index())
 
     paf_data = pd.concat(paf)
 
     if entity == coverage_gaps.low_measles_vaccine_coverage_first_dose:
-        paf_data['rei_id'] = entity.gbd_id
+        paf_data['risk_id'] = entity.gbd_id
         paf_data['coverage_gap_id'] = entity.gbd_id
 
     return paf_data
@@ -655,7 +659,7 @@ def _get_exposure(entities, location_ids):
             for entity in entities:
                 measure_data = gbd.get_auxiliary_data('exposure', 'coverage_gap', entity.name)
                 measure_data = measure_data[measure_data.location_id.isin(location_ids)]
-                measure_data['coverage_gap_id'] = np.NaN
+                measure_data['coverage_gap'] = entity.name
                 del measure_data['measure']
                 df.append(measure_data)
         exposure_data = pd.concat(df)

--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -22,7 +22,7 @@ class ArtifactBuilder:
 
         self.location = builder.configuration.input_data.location
         self.artifact = Artifact(path, filter_terms=[f'draw == {draw}', get_location_term(self.location)])
-        self.modeled_causes = builder.components.get_components(DiseaseModel)
+        self.modeled_causes = {c.cause for c in builder.components.get_components(DiseaseModel)}
         self.processed_entities = set()
         self.start_time = datetime.now()
 

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -163,7 +163,7 @@ def _build_artifact():
     _setup_logging(args.output_root, args.verbose, args.location,
                    args.model_specification, args.append)
 
-    formatted_location = args.location.replace('_', ' ')
+    formatted_location = args.location.replace('_', ' ') if args.location else args.location
     try:
         main(args.model_specification, args.output_root, formatted_location, args.append)
     except (BdbQuit, KeyboardInterrupt):

--- a/src/vivarium_inputs/data_artifact/loaders.py
+++ b/src/vivarium_inputs/data_artifact/loaders.py
@@ -1,4 +1,4 @@
-from typing import Collection
+from typing import Set
 import warnings
 
 from gbd_mapping import causes, risk_factors, sequelae, coverage_gaps, covariates, etiologies
@@ -27,7 +27,7 @@ CAUSE_BY_ID = {c.gbd_id: c for c in causes if c is not None}
 RISK_BY_ID = {r.gbd_id: r for r in risk_factors}
 
 
-def loader(entity_key: EntityKey, location: str, modeled_causes: Collection[str], all_measures: bool=False):
+def loader(entity_key: EntityKey, location: str, modeled_causes: Set[str], all_measures: bool=False):
     entity_data = {
         "cause": {
             "mapping": causes,
@@ -327,7 +327,7 @@ def _get_risk_metadata(risk, measure, modeled_causes):
         else:
             data = None
     elif measure == "affected_causes":
-        data = [c.name for c in risk.affected_causes if c in modeled_causes]
+        data = [c.name for c in risk.affected_causes if c.name in modeled_causes]
     else:  # measure == "distribution"
         data = risk[measure]
     return data
@@ -393,7 +393,7 @@ def _get_coverage_gap_metadata(coverage_gap, measure, modeled_causes):
     if measure in ["restrictions", "levels"]:
         data = coverage_gap[measure].to_dict()
     elif measure == "affected_causes":
-        data = [c.name for c in coverage_gap.affected_causes if c in modeled_causes]
+        data = [c.name for c in coverage_gap.affected_causes if c.name in modeled_causes]
     elif measure == "affected_risk_factors":
         data = [r.name for r in coverage_gap.affected_risk_factors]
     else:  # measure == "distribution"

--- a/src/vivarium_inputs/data_artifact/loaders.py
+++ b/src/vivarium_inputs/data_artifact/loaders.py
@@ -437,7 +437,7 @@ def _get_coverage_gap_population_attributable_fraction(coverage_gap, location):
 
 def _handle_coverage_gap_rr_paf(data):
     data = normalize(data)
-    data = data.rename(columns={'cause_id': 'cause', 'rei_id': 'risk_factor'})
+    data = data.rename(columns={'cause_id': 'cause', 'risk_id': 'risk_factor'})
     if data['cause'].dropna().unique().size > 0:
         for cid in data['cause'].dropna().unique():
             data['cause'] = data['cause'].apply(lambda c: CAUSE_BY_ID[c].name if c == cid else c)


### PR DESCRIPTION
Quick fixes to have an artifact builder correctly load the coverage gap data. Since coverage gap data can both come from gbd and auxiliary data source, it is messier and does not have very standardized form yet. There should be more fixes to clean up as we get more coverage gap data coming in. For now, I let it go as it is. **But current any function (get exposure/relative_risk/paf) which may use coverage gap in core is very fragile. Please be careful when you have to change/drop any column name to make a change in those functions**