### PR TITLE
only load data as needed

### DIFF
--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -47,7 +47,4 @@ class ArtifactBuilder:
 
 
 def _worker(entity_key: EntityKey, location: str, modeled_causes: Collection[str], artifact: Artifact) -> None:
-    for measure, data in loader(entity_key, location, modeled_causes, all_measures=True):
-        key = entity_key.with_measure(measure)
-        if key not in artifact:
-            artifact.write(key, data)
+    artifact.write(entity_key, loader(entity_key, location, modeled_causes, all_measures=False))


### PR DESCRIPTION
Switching to only load data as needed, rather than pulling all measures if only one is needed. Pulling all data was breaking building artifacts for a lot of configs for me - e.g., anytime a cause is included in a config that doesn't have mortality associated with it, it would still try to pull death data and break. 

All tests in other repos still pass with this change + smoke tests still run. 