### PR TITLE
fixing to properly store processed entities

### DIFF
--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -41,9 +41,9 @@ class ArtifactBuilder:
         _log.debug(f"Data loading took at most {datetime.now() - self.start_time} seconds")
 
     def process(self, entity_key: EntityKey) -> None:
-        if (entity_key.type, entity_key.name) not in self.processed_entities:
+        if entity_key not in self.processed_entities:
             _worker(entity_key, self.location, self.modeled_causes, self.artifact)
-            self.processed_entities.add((entity_key.type, entity_key.name))
+            self.processed_entities.add(entity_key)
 
 
 def _worker(entity_key: EntityKey, location: str, modeled_causes: Collection[str], artifact: Artifact) -> None:


### PR DESCRIPTION
This fixes the way that processed entity keys are stored in builder now that keys are only loaded as needed

Just built artifacts for three of the smoke tests to ensure that it actually works this time