### PR TITLE
Bugfix/disappearing builds

### DIFF
--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -56,14 +56,15 @@ def build_artifact(model_specification, locations, project,
 
     script_args = f"{script_path} {config_path} "
     if output_root:
-        output_base = pathlib.Path(output_root).resolve()
-        if not output_base.is_dir():
-            output_base.mkdir(parents=True)
         script_args += f"--output_root {output_root} "
     if append:
         script_args += f"--append "
     if verbose:
         script_args += f"--verbose "
+
+    # make directory if it doesn't exist up front because jobs fail before getting
+    # to making it later
+    get_output_base(output_root)
 
     num_locations = len(locations)
     if num_locations > 0:

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -56,6 +56,9 @@ def build_artifact(model_specification, locations, project,
 
     script_args = f"{script_path} {config_path} "
     if output_root:
+        output_base = pathlib.Path(output_root).resolve()
+        if not output_base.is_dir():
+            output_base.mkdir(parents=True)
         script_args += f"--output_root {output_root} "
     if append:
         script_args += f"--append "
@@ -331,8 +334,6 @@ def _setup_logging(output_root, verbose, location,
 
     """
 
-    # this will raise an error if the passed output_root doesn't exist which gets
-    # printed to console b/c logging isn't set up yet
     output_log_dir = get_output_base(output_root) / 'logs'
 
     if not output_log_dir.is_dir():


### PR DESCRIPTION
Fixing the bug where specifying an output path would cause your jobs to die without any logs (caused by a mismatch between dashes and underscores in specifying the arg in different places)

Also adding option to create SGE error logs to more easily diagnose issues like this in the future