### PR TITLE
add config filter term to passthrough

### DIFF
--- a/src/vivarium_inputs/data_artifact/passthrough.py
+++ b/src/vivarium_inputs/data_artifact/passthrough.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import pandas as pd
-from vivarium_public_health.dataset_manager import EntityKey, filter_data
+from vivarium_public_health.dataset_manager import EntityKey, filter_data, validate_filter_term
 from vivarium_public_health.disease import DiseaseModel
 
 from vivarium_inputs.data_artifact.loaders import loader
@@ -16,6 +16,7 @@ class ArtifactPassthrough:
 
         self.base_filter = {'draw': draw,
                             'location': [self.location, 'Global']}
+        self.config_filter_term = validate_filter_term(builder.configuration.input_data.artifact_filter_term)
 
     def load(self, entity_key: str, keep_age_group_edges: bool=True, **column_filters: str) -> Any:
         entity_key = EntityKey(entity_key)
@@ -25,5 +26,5 @@ class ArtifactPassthrough:
             for key, val in self.base_filter.items():
                 if key in data.columns:
                     column_filters[key] = val
-            data = filter_data(data, keep_age_group_edges, **column_filters)
+            data = filter_data(data, keep_age_group_edges, self.config_filter_term, **column_filters)
         return data


### PR DESCRIPTION
Applies filter term specified in config to data pulled via passthrough. Matches w/ PR in vph

Tested by specifying a filter term in config restricting years and then trying to run sim outside those years w/o extrapolation with passthrough to make sure it fails

Travis fails tests because needs methods added in vivarium_public_health PR but tests all pass locally when I'm on both branches. 