### PR TITLE
Feature/new cluster

### DIFF
--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -28,8 +28,18 @@ from vivarium.config_tree import ConfigTree
               help="Turn on debug mode for logging")
 @click.option('--pdb', 'debugger', is_flag=True, help='Drop the debugger if an error occurs')
 def build_artifact(model_specification, output_root, append, verbose, debugger):
-    """ On the new cluster, this requires specifically requesting J drive access in your
-    qlogin by adding the flag -l archive=TRUE"""
+    """
+    build_artifact is a program for building data artifacts locally
+    from a MODEL_SPECIFICATION file.  It requires access to the J drive and,
+    depending on where the output is sent, /ihme as well.
+
+    Any artifact.path specified in the configuration file is guaranteed to
+    be overwritten either by the optional output_root option or a predetermined
+    path based on username: /ihme/scratch/users/{user}/vivarium_artifacts
+
+    If you are running this job from a qlogin on the new cluster, you must
+    specifically request J drive access when you qlogin by adding "-l archive=TRUE"
+    to your qsub command."""
     _build_artifact()
 
 
@@ -54,24 +64,27 @@ def build_artifact(model_specification, output_root, append, verbose, debugger):
 def multi_build_artifact(model_specification, locations, project,
                    output_root, append, verbose, error_logs, memory):
     """
-    build_artifact is a program for building data artifacts from a
-    MODEL_SPECIFICATION file. The work is offloaded to the cluster
+    multi_build_artifact is a program for building data artifacts on the cluster
+    from a MODEL_SPECIFICATION file.
+
+    This script necessarily offloads work to the cluster, and so requires being
+    run in the cluster environment.  It will qsub jobs for building artifacts
     under the "proj_cost_effect" project unless a different project is
     specified. Multiple, optional LOCATIONS can be provided to overwrite
     the configuration file. For locations containing spaces, replace the
     space with an underscore and surround any locations containing 
     apostrophes with double quotes, e.g.:
 
-    build_artifact examply.yaml Virginia Pennsylvania New_York "Cote_d'Ivoire"
+    build_artifact example.yaml Virginia Pennsylvania New_York "Cote_d'Ivoire"
 
     Any artifact.path specified in the configuration file is guaranteed to
     be overwritten either by the optional output_root or a predetermined path
     based on user: /ihme/scratch/users/{user}/vivarium_artifacts
 
-    This script necessarily offloads work to the cluster, and so requires being
-    run in the cluster environment. To run locally, execute this script directly,
-    as in `python cli.py`. The API is the same, and help can be accessed using
-    -h / --help.
+    If you are running this on the new cluster and find your jobs failing with no
+    messages in the log files, consider the memory usage of the job by typing
+    "qacct -j <job_id>" and the default memory usage used by this script of 10G.
+    The new cluster will kill jobs that go over memory without giving a useful message.
     """
 
     config_path = pathlib.Path(model_specification).resolve()

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -74,7 +74,7 @@ def multi_build_artifact(model_specification, locations, project,
     python_context_path = pathlib.Path(shutil.which("python")).resolve()
     script_path = pathlib.Path(__file__).resolve()
 
-    if output_root.startswith("/home/j/") or output_root.startswith('/snfs1/'):
+    if (output_root) and (output_root.startswith("/home/j/") or output_root.startswith('/snfs1/')):
         archive = True
     else:
         archive = False
@@ -91,7 +91,7 @@ def multi_build_artifact(model_specification, locations, project,
 
     num_locations = len(locations)
     if num_locations > 0:
-        script_args += "--location {}"
+        script_args += "--location {} "
         for i, location in enumerate(locations):
             location = location.replace("'", "-")
             job_name = f"{config_path.stem}_{location}_build_artifact"
@@ -161,21 +161,23 @@ def build_submit_command(python_context_path: str, job_name: str, project: str, 
     """
 
     logs = f"-e {str(error_log_dir)}" if error_log_dir else ""
-    command = f"qsub -N {job_name} {logs} -b y {python_context_path}"
+    command = f"qsub -N {job_name} {logs} "
 
     if os.environ['SGE_CLUSTER_NAME'] == 'cluster':
-        command += f" -l fthread={slots}"
-        command += ' -l m_mem_free=4G'
-        command += f" -P {project}"
+        command += f"-l fthread={slots} "
+        command += "-l m_mem_free=4G "
+        command += f"-P {project} "
         if archive:
-            command += ' -l archive=TRUE'
+            command += '-l archive=TRUE '
         else:
-            command += ' -l archive=FALSE'
-    elif os.environ['SGE_CLUSTER_NAME'] == "prod":
-        command += f" -pe multi_slot {slots}"
-        command += f" -P {project}"
+            command += '-l archive=FALSE '
+    elif os.environ['SGE_CLUSTER_NAME'] == 'prod':
+        command += f"-pe multi_slot {slots} "
+        command += f"-P {project} "
     else:  # dev
-        command += f" -pe multi_slot {slots}"
+        command += f"-pe multi_slot {slots} "
+
+    command += f"-b y {python_context_path} "
 
     return command + script_args
 

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -75,7 +75,7 @@ def multi_build_artifact(model_specification, locations, project,
     space with an underscore and surround any locations containing 
     apostrophes with double quotes, e.g.:
 
-    build_artifact example.yaml Virginia Pennsylvania New_York "Cote_d'Ivoire"
+    multi_build_artifact example.yaml Virginia Pennsylvania New_York "Cote_d'Ivoire"
 
     Any artifact.path specified in the configuration file is guaranteed to
     be overwritten either by the optional output_root or a predetermined path

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -28,6 +28,8 @@ from vivarium.config_tree import ConfigTree
               help="Turn on debug mode for logging")
 @click.option('--pdb', 'debugger', is_flag=True, help='Drop the debugger if an error occurs')
 def build_artifact(model_specification, output_root, append, verbose, debugger):
+    """ On the new cluster, this requires specifically requesting J drive access in your
+    qlogin by adding the flag -l archive=TRUE"""
     _build_artifact()
 
 
@@ -48,7 +50,7 @@ def build_artifact(model_specification, output_root, append, verbose, debugger):
 @click.option('--error_logs', '-e', is_flag=True,
               help="Write SGE error logs to output location")
 @click.option('--memory', '-m', default=10, help="Specifies the amount of memory in G that will be requested for a "
-                                                 "job. Defaults to 10.")
+                                                 "job. Defaults to 10. Only applies to the new cluster.")
 def multi_build_artifact(model_specification, locations, project,
                    output_root, append, verbose, error_logs, memory):
     """


### PR DESCRIPTION
This adds support for the new cluster. It also updates the click command docstrings.

There is a new click option for multi_build_artifact, memory. This allows specification of memory that will go in to the qsub command. On the new cluster this is an issue because the build jobs will be killed if over memory (incidentally, there is no message when it happens). I imagine memory usage can very pretty wildly from artifact to artifact so having a tuneable switch was important.

I tested build_artifact and multi_build_artifact on the new and old clusters with the rota.yaml and various countries. 