### PR TITLE
Refactor/change in hdf creation

### DIFF
--- a/src/vivarium_inputs/data_artifact/__init__.py
+++ b/src/vivarium_inputs/data_artifact/__init__.py
@@ -1,3 +1,3 @@
-from .builder import ArtifactBuilder
+from .builder import ArtifactBuilder, OutdatedArtifactWarning
 from .passthrough import ArtifactPassthrough
 from .utilities import normalize, get_versions

--- a/src/vivarium_inputs/data_artifact/__init__.py
+++ b/src/vivarium_inputs/data_artifact/__init__.py
@@ -1,3 +1,3 @@
 from .builder import ArtifactBuilder
 from .passthrough import ArtifactPassthrough
-from .utilities import normalize
+from .utilities import normalize, get_versions

--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -59,26 +59,27 @@ class ArtifactBuilder:
 
             try:
                 artifact = Artifact(path, filter_terms=[f'draw == {draw}', get_location_term(location)])
-                if EntityKey('metadata.locations') not in artifact:
-                    warnings.warn('We will build from scratch', OutdatedArtifactWarning)
-                    artifact = create_new_artifact(path, draw, location)
-
-                elif artifact.load('metadata.locations') != [location]:
-                    raise ValueError(f"Artifact has {artifact.load('metadata.locations')} and we cannot append {location}")
-
-                if EntityKey('metadata.versions') not in artifact:
-                    warnings.warn('We will build from scratch', OutdatedArtifactWarning)
-                    artifact = create_new_artifact(path, draw, location)
-
-                elif artifact.load('metadata.versions') != get_versions():
-                    warnings.warn('Your artifact was made under different versions. We will wipe it out', DeprecationWarning)
-                    artifact = create_new_artifact(path, draw, location)
 
             except NoSuchNodeError:
                 #  it means that path was a file but does not have metadata.keyspace inside
                 warnings.warn('We will wipe it out and build from scratch', OutdatedArtifactWarning)
                 artifact = create_new_artifact(path, draw, location)
 
+            if EntityKey('metadata.locations') not in artifact:
+                warnings.warn('We will build from scratch', OutdatedArtifactWarning)
+                artifact = create_new_artifact(path, draw, location)
+
+            elif artifact.load('metadata.locations') != [location]:
+                raise ValueError(f"Artifact has {artifact.load('metadata.locations')} and we cannot append {location}")
+
+            if EntityKey('metadata.versions') not in artifact:
+                warnings.warn('We will build from scratch', OutdatedArtifactWarning)
+                artifact = create_new_artifact(path, draw, location)
+
+            elif artifact.load('metadata.versions') != get_versions():
+                warnings.warn('Your artifact was made under different versions. We will wipe it out',
+                              OutdatedArtifactWarning)
+                artifact = create_new_artifact(path, draw, location)
         else:
             artifact = create_new_artifact(path, draw, location)
 

--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -1,16 +1,17 @@
 from datetime import datetime
 import logging
+import warnings
 from typing import Collection, Any
 import pandas as pd
-import pkg_resources
+from pathlib import Path
 
-from vivarium_public_health.dataset_manager import (EntityKey, Artifact, get_location_term, ArtifactException,
-                                                    filter_data, hdf)
+from vivarium_public_health.dataset_manager import (EntityKey, Artifact, get_location_term, filter_data)
 
 from vivarium_public_health.disease import DiseaseModel
 
 from vivarium_inputs.data_artifact.loaders import loader
 from vivarium_inputs.forecasting import load_forecast
+from vivarium_inputs.data_artifact.utilities import get_versions
 
 
 _log = logging.getLogger(__name__)
@@ -26,16 +27,10 @@ class ArtifactBuilder:
     def setup(self, builder):
         path = builder.configuration.input_data.artifact_path
         append = builder.configuration.input_data.append_to_artifact
-
         draw = builder.configuration.input_data.input_draw_number
-
         self.location = builder.configuration.input_data.location
-        if not append:
-            hdf.touch(path)
-            hdf.write(path, EntityKey('metadata.keyspace'), ['metadata.keyspace'])
+        self.artifact = self.initialize_artifact(path, append, draw, self.location)
 
-        self.artifact = Artifact(path, filter_terms=[f'draw == {draw}', get_location_term(self.location)])
-        self.write_metadata(append)
         self.modeled_causes = {c.cause for c in builder.components.get_components(DiseaseModel)}
         self.processed_entities = set()
         self.start_time = datetime.now()
@@ -44,21 +39,42 @@ class ArtifactBuilder:
 
         builder.event.register_listener('post_setup', self.end_processing)
 
-    def write_metadata(self, append):
-        if append:
-            try:
-                self.artifact.remove('metadata.locations')
-                self.artifact.remove('metadata.versions')
-            except ArtifactException:
-                # FIXME: We do not have a good plan to deal with appending an old artifact
-                _log.debug('You provided an outdated artifact. We will build from scratch')
-                hdf.touch(self.artifact.path)
-                hdf.write(self.artifact.path, EntityKey('metadata.keyspace'), ['metadata.keyspace'])
+    @staticmethod
+    def initialize_artifact(path, append, draw, location):
+        def create_new_artifact():
+            art = Artifact(path, filter_terms=[f'draw == {draw}', get_location_term(location)])
+            art.write('metadata.versions', get_versions())
+            art.write('metadata.locations', [location])
+            return art
 
-        current_versions = {k: pkg_resources.get_distribution(k).version for k in
-                            ['vivarium', 'vivarium_inputs', 'vivarium_public_health', 'gbd_mapping']}
-        self.artifact.write('metadata.versions', current_versions)
-        self.artifact.write('metadata.locations', [self.location])
+        if not append:
+            if Path(path).is_file():
+                path(path).unlink()
+            artifact = create_new_artifact()
+
+        else:
+            artifact = Artifact(path, filter_terms=[f'draw == {draw}', get_location_term(location)])
+            if EntityKey('metadata.keyspace') not in artifact:
+                _log.debug('This is an outdated artifact. We will build from scratch')
+                Path(path).unlink()
+                artifact = create_new_artifact()
+
+            if EntityKey('metadata.locations') not in artifact:
+                _log.debug('This is an outdated artifact. We will build from scratch')
+                artifact = create_new_artifact()
+
+            elif artifact.load('metadata.locations')!= [location]:
+                raise ValueError(f"Artifact has {artifact.load('metadata.locations')} and we cannot append {location}")
+
+            if EntityKey('metadata.versions') not in artifact:
+                _log.debug('This is an outdated artifact. We will build from scratch')
+                artifact = create_new_artifact()
+
+            elif artifact.load('metadata.versions') != get_versions():
+                warnings.warn('Your artifact was made under different versions. We will wipe it out', DeprecationWarning)
+                artifact = create_new_artifact()
+
+        return artifact
 
     def load(self, entity_key: str, future=False, **__) -> Any:
         entity_key = EntityKey(entity_key)

--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import logging
 import warnings
+from tables.exceptions import NoSuchNodeError
 from typing import Collection, Any
 import pandas as pd
 from pathlib import Path
@@ -15,6 +16,10 @@ from vivarium_inputs.data_artifact.utilities import get_versions
 
 
 _log = logging.getLogger(__name__)
+
+
+class OutdatedArtifactWarning(Warning):
+    pass
 
 
 class ArtifactBuilder:
@@ -40,39 +45,42 @@ class ArtifactBuilder:
         builder.event.register_listener('post_setup', self.end_processing)
 
     @staticmethod
-    def initialize_artifact(path, append, draw, location):
-        def create_new_artifact():
-            art = Artifact(path, filter_terms=[f'draw == {draw}', get_location_term(location)])
-            art.write('metadata.versions', get_versions())
-            art.write('metadata.locations', [location])
-            return art
+    def initialize_artifact(path: str, append: bool, draw: int, location: str) -> Artifact:
+        """
+        For the given arguments, it checks all the basic conditions and
+        initialize the artifact. For now, all the outdated artifacts which
+        do not have proper metadata or not consistent metadata will not be
+        appended. we will wipe it out and build a new artifact.
+        """
 
-        if not append:
-            if Path(path).is_file():
-                Path(path).unlink()
-            artifact = create_new_artifact()
+        if append:
+            if not Path(path).is_file():
+                raise ValueError(f'{path} is not a file. You should provide the existing artifact path to append')
+
+            try:
+                artifact = Artifact(path, filter_terms=[f'draw == {draw}', get_location_term(location)])
+                if EntityKey('metadata.locations') not in artifact:
+                    warnings.warn('We will build from scratch', OutdatedArtifactWarning)
+                    artifact = create_new_artifact(path, draw, location)
+
+                elif artifact.load('metadata.locations') != [location]:
+                    raise ValueError(f"Artifact has {artifact.load('metadata.locations')} and we cannot append {location}")
+
+                if EntityKey('metadata.versions') not in artifact:
+                    warnings.warn('We will build from scratch', OutdatedArtifactWarning)
+                    artifact = create_new_artifact(path, draw, location)
+
+                elif artifact.load('metadata.versions') != get_versions():
+                    warnings.warn('Your artifact was made under different versions. We will wipe it out', DeprecationWarning)
+                    artifact = create_new_artifact(path, draw, location)
+
+            except NoSuchNodeError:
+                #  it means that path was a file but does not have metadata.keyspace inside
+                warnings.warn('We will wipe it out and build from scratch', OutdatedArtifactWarning)
+                artifact = create_new_artifact(path, draw, location)
 
         else:
-            artifact = Artifact(path, filter_terms=[f'draw == {draw}', get_location_term(location)])
-            if EntityKey('metadata.keyspace') not in artifact:
-                _log.debug('This is an outdated artifact. We will build from scratch')
-                Path(path).unlink()
-                artifact = create_new_artifact()
-
-            if EntityKey('metadata.locations') not in artifact:
-                _log.debug('This is an outdated artifact. We will build from scratch')
-                artifact = create_new_artifact()
-
-            elif artifact.load('metadata.locations')!= [location]:
-                raise ValueError(f"Artifact has {artifact.load('metadata.locations')} and we cannot append {location}")
-
-            if EntityKey('metadata.versions') not in artifact:
-                _log.debug('This is an outdated artifact. We will build from scratch')
-                artifact = create_new_artifact()
-
-            elif artifact.load('metadata.versions') != get_versions():
-                warnings.warn('Your artifact was made under different versions. We will wipe it out', DeprecationWarning)
-                artifact = create_new_artifact()
+            artifact = create_new_artifact(path, draw, location)
 
         return artifact
 
@@ -99,3 +107,12 @@ def _worker(entity_key: EntityKey, location: str, modeled_causes: Collection[str
     else:
         data = loader(entity_key, location, modeled_causes, all_measures=False)
     artifact.write(entity_key, data)
+
+
+def create_new_artifact(path: str, draw: int, location: str) -> Artifact:
+    if Path(path).is_file():
+        Path(path).unlink()
+    art = Artifact(path, filter_terms=[f'draw == {draw}', get_location_term(location)])
+    art.write('metadata.versions', get_versions())
+    art.write('metadata.locations', [location])
+    return art

--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -49,7 +49,7 @@ class ArtifactBuilder:
 
         if not append:
             if Path(path).is_file():
-                path(path).unlink()
+                Path(path).unlink()
             artifact = create_new_artifact()
 
         else:

--- a/src/vivarium_inputs/data_artifact/utilities.py
+++ b/src/vivarium_inputs/data_artifact/utilities.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pkg_resources
 
 from vivarium_inputs.utilities import normalize_for_simulation, get_age_group_bins_from_age_group_id
 from vivarium_inputs import core
@@ -20,3 +21,9 @@ def normalize(data: pd.DataFrame) -> pd.DataFrame:
     if "year_start" in data:
         data = data.loc[(data.year_start >= year_start) & (data.year_end <= year_end)]
     return data
+
+
+def get_versions():
+
+    libraries = ['vivarium', 'vivarium_inputs', 'vivarium_public_health', 'gbd_mapping']
+    return {k: pkg_resources.get_distribution(k).version for k in libraries}

--- a/tests/data_artifact/test_builder.py
+++ b/tests/data_artifact/test_builder.py
@@ -1,0 +1,92 @@
+import pytest
+
+from pathlib import Path
+from vivarium_inputs.data_artifact import ArtifactBuilder, OutdatedArtifactWarning
+from vivarium_public_health.dataset_manager import EntityKey
+
+
+@pytest.fixture()
+def test_artifact(tmpdir):
+    path = Path(tmpdir)/'test.hdf'
+    location = 'United States'
+    draw = 0
+    artifact = ArtifactBuilder.initialize_artifact(path.as_posix(), False, draw, location)
+    return artifact
+
+
+def test_initialize_artifact_append_not_a_file(tmpdir):
+    path = Path(tmpdir)/'test.hdf'
+    location = 'United States'
+    draw = 0
+
+    with pytest.raises(ValueError):
+        ArtifactBuilder.initialize_artifact(path.as_posix(), True, draw, location)
+
+
+def test_initialize_artifact_append_keyspace(test_artifact):
+    draw = 0
+    location = 'United States'
+
+    # artifact without a keyspace
+    test_artifact.remove('metadata.keyspace')
+    assert EntityKey('metadata.keyspace') not in test_artifact
+
+    with pytest.warns(OutdatedArtifactWarning):
+        artifact = ArtifactBuilder.initialize_artifact(test_artifact.path, True, draw, location)
+        assert EntityKey('metadata.keyspace') in artifact
+
+
+def test_initialize_artifact_append_locations(test_artifact):
+    draw = 0
+    location = 'United States'
+
+    # artifact without a location
+    test_artifact.remove('metadata.locations')
+    assert EntityKey('metadata.locations') not in test_artifact
+
+    with pytest.warns(OutdatedArtifactWarning):
+        artifact = ArtifactBuilder.initialize_artifact(test_artifact.path, True, draw, location)
+        assert EntityKey('metadata.locations') in artifact
+        assert artifact.load('metadata.locations') == [location]
+
+    # artifact with a different location
+    new_location = 'Canada'
+    assert artifact.load('metadata.locations') == [location]
+
+    with pytest.raises(ValueError):
+        ArtifactBuilder.initialize_artifact(test_artifact.path, True, draw, new_location)
+
+
+def test_initialize_artifact_append_versions(test_artifact):
+    draw = 0
+    location = 'United States'
+
+    # artifact without versions
+    test_artifact.remove('metadata.versions')
+    assert EntityKey('metadata.versions') not in test_artifact
+
+    with pytest.warns(OutdatedArtifactWarning):
+        artifact = ArtifactBuilder.initialize_artifact(test_artifact.path, True, draw, location)
+        assert EntityKey('metadata.versions') in artifact
+
+    current_versions = artifact.load('metadata.versions')
+    new_versions = {k: '0.1' for k in current_versions}
+    artifact.replace('metadata.versions', new_versions)
+
+    assert artifact.load('metadata.versions') == new_versions
+
+    with pytest.warns(DeprecationWarning):
+        artifact = ArtifactBuilder.initialize_artifact(test_artifact.path, True, draw, location)
+        assert artifact.load('metadata.versions') == current_versions
+
+
+def test_initialize_artifact_no_append_file(test_artifact):
+    draw = 0
+    location = 'United States'
+
+    test_artifact.write('test.key', 'data')
+    assert EntityKey('test.key') in test_artifact
+
+    # check whether the existing file wiped out
+    artifact = ArtifactBuilder.initialize_artifact(test_artifact.path, False, draw, location)
+    assert EntityKey('test.key') not in artifact

--- a/tests/data_artifact/test_builder.py
+++ b/tests/data_artifact/test_builder.py
@@ -75,7 +75,7 @@ def test_initialize_artifact_append_versions(test_artifact):
 
     assert artifact.load('metadata.versions') == new_versions
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(OutdatedArtifactWarning):
         artifact = ArtifactBuilder.initialize_artifact(test_artifact.path, True, draw, location)
         assert artifact.load('metadata.versions') == current_versions
 


### PR DESCRIPTION
This is another bit of current VPH PR#51 before bringing in the multiple location artifacts. With this change, appending logic only stays in the builder and artifact will create hdf only if the given file path is not a file