### PR TITLE
Add validation context, sim validator estimation year refactor

### DIFF
--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -6,11 +6,9 @@ from gbd_mapping import Cause, Sequela, RiskFactor, CoverageGap, Etiology, Covar
 import pandas as pd
 import numpy as np
 
-from vivarium_inputs import utilities, extract
+from vivarium_inputs import utilities, extract, utility_data
 from vivarium_inputs.globals import InvalidQueryError, DEMOGRAPHIC_COLUMNS, MEASURES, SEXES, Population, gbd
 from vivarium_inputs.mapping_extension import AlternativeRiskFactor, HealthcareEntity, HealthTechnology
-
-
 
 
 def get_data(entity, measure: str, location: str):
@@ -41,7 +39,6 @@ def get_data(entity, measure: str, location: str):
         'structure': (get_structure, ('population',)),
         'theoretical_minimum_risk_life_expectancy': (get_theoretical_minimum_risk_life_expectancy, ('population',)),
         'age_bins': (get_age_bins, ('population',)),
-        'estimation_years': (get_estimation_years, ('population',)),
         'demographic_dimensions': (get_demographic_dimensions, ('population',))
 
     }
@@ -338,16 +335,9 @@ def get_age_bins(entity: Population, location_id: int) -> pd.DataFrame:
     return age_bins
 
 
-def get_estimation_years(entity: Population, location_id: int) -> pd.DataFrame:
-    estimation_years = extract.extract_data(entity, 'estimation_years', location_id)
-    estimation_years = pd.DataFrame({'year_start': range(min(estimation_years), max(estimation_years) + 1)})
-    estimation_years['year_end'] = estimation_years['year_start'] + 1
-    return estimation_years
-
-
 def get_demographic_dimensions(entity: Population, location_id: int, draws: bool = False) -> pd.DataFrame:
     ages = gbd.get_age_group_id()
-    estimation_years = extract.extract_data(entity, 'estimation_years', location_id)
+    estimation_years = utility_data.get_estimation_years()
     years = range(min(estimation_years), max(estimation_years) + 1)
     sexes = [SEXES['Male'], SEXES['Female']]
     location = [location_id]

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -25,6 +25,7 @@ def get_data(entity, measure: str, location: str):
         'case_fatality': (get_case_fatality, ('cause',)),
         # Risk-like measures
         'exposure': (get_exposure, ('risk_factor', 'coverage_gap', 'alternative_risk_factor',)),
+        'exposure_age_groups': (get_exposure_age_groups, ('risk_factor', 'alternative_risk_factor',)),
         'exposure_standard_deviation': (get_exposure_standard_deviation, ('risk_factor', 'alternative_risk_factor')),
         'exposure_distribution_weights': (get_exposure_distribution_weights, ('risk_factor', 'alternative_risk_factor')),
         'relative_risk': (get_relative_risk, ('risk_factor', 'coverage_gap')),
@@ -39,7 +40,9 @@ def get_data(entity, measure: str, location: str):
         'structure': (get_structure, ('population',)),
         'theoretical_minimum_risk_life_expectancy': (get_theoretical_minimum_risk_life_expectancy, ('population',)),
         'age_bins': (get_age_bins, ('population',)),
+        'estimation_years': (get_estimation_years, ('population',)),
         'demographic_dimensions': (get_demographic_dimensions, ('population',))
+
     }
 
     if measure not in measure_handlers:
@@ -171,6 +174,11 @@ def get_exposure(entity: Union[RiskFactor, AlternativeRiskFactor, CoverageGap], 
         data = utilities.normalize(data, fill_value=0)
     data = utilities.reshape(data, to_keep=DEMOGRAPHIC_COLUMNS + ['parameter'])
     return data
+
+
+def get_exposure_age_groups(entity: RiskFactor, location_id: int):
+    exposure = extract.extract_data(entity, 'exposure', location_id)
+    return set(exposure.age_group_id)
 
 
 def get_exposure_standard_deviation(entity: Union[RiskFactor, AlternativeRiskFactor], location_id: int) -> pd.DataFrame:
@@ -329,12 +337,15 @@ def get_age_bins(entity: Population, location_id: int) -> pd.DataFrame:
     return age_bins
 
 
+def get_estimation_years(entity: Population, location_id: int) -> pd.DataFrame:
+    estimation_years = extract.extract_data(entity, 'estimation_years', location_id)
+    estimation_years = pd.DataFrame({'year_start': range(min(estimation_years), max(estimation_years) + 1)})
+    estimation_years['year_end'] = estimation_years['year_start'] + 1
+    return estimation_years
+
+
 def get_demographic_dimensions(entity: Population, location_id: int) -> pd.DataFrame:
     demographic_dimensions = utilities.get_demographic_dimensions(location_id)
     demographic_dimensions = utilities.normalize(demographic_dimensions)
     return demographic_dimensions
 
-
-def get_exposure_age_groups(entity: RiskFactor, location_id: int):
-    exposure = extract.extract_data(entity, 'exposure', location_id)
-    return set(exposure.age_group_id)

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -6,37 +6,36 @@ import pandas as pd
 
 from vivarium_inputs.globals import gbd, METRICS, MEASURES, DataAbnormalError, DataDoesNotExistError
 from vivarium_inputs.utilities import filter_to_most_detailed_causes
+from vivarium_inputs.utility_data import get_estimation_years
 import vivarium_inputs.validation.raw as validation
 
 
 def extract_data(entity, measure: str, location_id: int) -> Union[pd.Series, pd.DataFrame]:
     extractors = {
         # Cause-like measures
-        'incidence': (extract_incidence, (extract_estimation_years,)),
-        'prevalence': (extract_prevalence, (extract_estimation_years,)),
-        'birth_prevalence': (extract_birth_prevalence, (extract_estimation_years,)),
+        'incidence': (extract_incidence, (get_estimation_years,)),
+        'prevalence': (extract_prevalence, (get_estimation_years,)),
+        'birth_prevalence': (extract_birth_prevalence, (get_estimation_years,)),
         'disability_weight': (extract_disability_weight, ()),
-        'remission': (extract_remission, (extract_estimation_years,)),
-        'deaths': (extract_deaths, (extract_estimation_years,)),
+        'remission': (extract_remission, (get_estimation_years,)),
+        'deaths': (extract_deaths, (get_estimation_years,)),
         # Risk-like measures
-        'exposure': (extract_exposure, (extract_estimation_years, )),
+        'exposure': (extract_exposure, (get_estimation_years, )),
         'exposure_standard_deviation': (extract_exposure_standard_deviation,
-                                        (extract_exposure, extract_estimation_years)),
+                                        (extract_exposure, get_estimation_years)),
         'exposure_distribution_weights': (extract_exposure_distribution_weights, ()),
-        'relative_risk': (extract_relative_risk, (extract_exposure, extract_estimation_years)),
+        'relative_risk': (extract_relative_risk, (extract_exposure, get_estimation_years)),
         'population_attributable_fraction': (extract_population_attributable_fraction,
-                                             (extract_estimation_years,)),
+                                             (get_estimation_years,)),
         'mediation_factors': (extract_mediation_factors, ()),
         # Covariate measures
-        'estimate': (extract_estimate, (extract_estimation_years,)),
+        'estimate': (extract_estimate, (get_estimation_years,)),
         # Health system measures
-        'cost': (extract_cost, (extract_estimation_years,)),
-        'utilization': (extract_utilization, (extract_estimation_years,)),
+        'cost': (extract_cost, (get_estimation_years,)),
+        'utilization': (extract_utilization, (get_estimation_years,)),
         # Population measures
-        'structure': (extract_structure, (extract_estimation_years,)),
+        'structure': (extract_structure, (get_estimation_years,)),
         'theoretical_minimum_risk_life_expectancy': (extract_theoretical_minimum_risk_life_expectancy, ()),
-        # Global values
-        'estimation_years': (extract_estimation_years, ()),
     }
 
     validation.check_metadata(entity, measure)
@@ -168,9 +167,4 @@ def extract_structure(entity, location_id: int) -> pd.DataFrame:
 
 def extract_theoretical_minimum_risk_life_expectancy(entity, location_id: int) -> pd.DataFrame:
     data = gbd.get_theoretical_minimum_risk_life_expectancy()
-    return data
-
-
-def extract_estimation_years(entity, location_id: int) -> pd.Series:
-    data = gbd.get_estimation_years()
     return data

--- a/src/vivarium_inputs/utilities.py
+++ b/src/vivarium_inputs/utilities.py
@@ -23,32 +23,6 @@ def get_age_bins():
     return age_bins
 
 
-def get_annual_year_bins():
-    estimation_years = gbd.get_estimation_years()
-    df = pd.DataFrame({'year_id': range(min(estimation_years), max(estimation_years) + 1)})
-
-    return scrub_year(df)
-
-
-def get_demographic_dimensions(location_id, draws=False):
-    ages = gbd.get_age_group_id()
-    estimation_years = gbd.get_estimation_years()
-    years = range(min(estimation_years), max(estimation_years) + 1)
-    sexes = [SEXES['Male'], SEXES['Female']]
-    location = [location_id]
-    values = [location, sexes, ages, years]
-    names = ['location_id', 'sex_id', 'age_group_id', 'year_id']
-    if draws:
-        values.append(range(1000))
-        names.append('draw')
-
-    dimensions = (pd.MultiIndex
-                  .from_product(values, names=names)
-                  .to_frame(index=False))
-
-    return dimensions
-
-
 ##################################################
 # Functions to remove GBD conventions from data. #
 ##################################################

--- a/src/vivarium_inputs/utility_data.py
+++ b/src/vivarium_inputs/utility_data.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+from vivarium_inputs.globals import gbd
+
+
+def get_estimation_years(*_, **__) -> pd.Series:
+    data = gbd.get_estimation_years()
+    return data
+
+
+def get_year_block() -> pd.DataFrame:
+    estimation_years = get_estimation_years()
+    year_block = pd.DataFrame({'year_start': range(min(estimation_years), max(estimation_years) + 1)})
+    year_block['year_end'] = estimation_years['year_start'] + 1
+    return year_block

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -4,9 +4,9 @@ import numpy as np
 import pandas as pd
 
 from gbd_mapping import ModelableEntity, Cause, Sequela, RiskFactor, CoverageGap, Etiology, Covariate
-from vivarium_inputs import utilities, core
+from vivarium_inputs import utilities, utility_data
 from vivarium_inputs.validation import utilities as validation_utilities
-from vivarium_inputs.globals import DataTransformationError, Population
+from vivarium_inputs.globals import DataTransformationError
 from vivarium_inputs.mapping_extension import HealthcareEntity, HealthTechnology, AlternativeRiskFactor
 
 
@@ -33,9 +33,9 @@ class SimulationValidationContext:
     def __init__(self, location, estimation_years: pd.DataFrame = None, **kwargs):
         self.context_data = {'location': location}
         if estimation_years is None:
-            self.context_data['estimation_years'] = core.get_data(Population(), 'estimation_years', location)
+            self.context_data['years'] = utility_data.get_year_block()
         else:
-            self.context_data['estimation_years'] = estimation_years
+            self.context_data['years'] = estimation_years
 
         self.context_data.update(kwargs)
 
@@ -473,7 +473,7 @@ def _validate_year_columns(data: pd.DataFrame, context: SimulationValidationCont
     if 'year_start' not in data.columns or 'year_end' not in data.columns:
         raise DataTransformationError("Year data must be contained in columns named 'year_start', and 'year_end'.")
 
-    expected_years = context['estimation_years'].sort_values(['year_start', 'year_end'])
+    expected_years = context['years'].sort_values(['year_start', 'year_end'])
     year_block = (data[['year_start', 'year_end']]
                   .drop_duplicates()
                   .sort_values(['year_start', 'year_end'])

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -4,9 +4,9 @@ import numpy as np
 import pandas as pd
 
 from gbd_mapping import ModelableEntity, Cause, Sequela, RiskFactor, CoverageGap, Etiology, Covariate
-from vivarium_inputs import utilities
+from vivarium_inputs import utilities, core
 from vivarium_inputs.validation import utilities as validation_utilities
-from vivarium_inputs.globals import DataTransformationError
+from vivarium_inputs.globals import DataTransformationError, Population
 from vivarium_inputs.mapping_extension import HealthcareEntity, HealthTechnology, AlternativeRiskFactor
 
 
@@ -28,8 +28,26 @@ VALID_POPULATION_RANGE = (0, 100_000_000)
 VALID_LIFE_EXP_RANGE = (0, 90)
 
 
-def validate_for_simulation(data: pd.DataFrame, entity: Union[ModelableEntity, NamedTuple], measure: str,
-                            location: str):
+class SimulationValidationContext:
+
+    def __init__(self, location, estimation_years: pd.DataFrame = None, **kwargs):
+        self.context_data = {'location': location}
+        if estimation_years is None:
+            self.context_data['estimation_years'] = core.get_data(Population(), 'estimation_years', location)
+        else:
+            self.context_data['estimation_years'] = estimation_years
+
+        self.context_data.update(kwargs)
+
+    def __getitem__(self, key):
+        return self.context_data[key]
+
+    def __setitem__(self, key, value):
+        self.context_data[key] = value
+
+
+def validate_for_simulation(data: pd.DataFrame, entity: Union[ModelableEntity, NamedTuple], measure: str, location: str,
+                            **context_args):
     """Validate data conforms to the format that is expected by the simulation and conforms to normal expectations for a
     measure.
 
@@ -62,7 +80,6 @@ def validate_for_simulation(data: pd.DataFrame, entity: Union[ModelableEntity, N
         'remission': _validate_remission,
         'cause_specific_mortality': _validate_cause_specific_mortality,
         'excess_mortality': _validate_excess_mortality,
-        'case_fatality': _validate_case_fatality,
         # Risk-like measures
         'exposure': _validate_exposure,
         'exposure_standard_deviation': _validate_exposure_standard_deviation,
@@ -85,11 +102,12 @@ def validate_for_simulation(data: pd.DataFrame, entity: Union[ModelableEntity, N
     if measure not in validators:
         raise NotImplementedError()
 
-    validators[measure](data, entity, location)
+    context = SimulationValidationContext(location, **context_args)
+    validators[measure](data, entity, context)
 
 
-def _validate_incidence(data: pd.DataFrame, entity: Union[Cause, Sequela], location: str):
-    _validate_standard_columns(data, location)
+def _validate_incidence(data: pd.DataFrame, entity: Union[Cause, Sequela], context: SimulationValidationContext):
+    _validate_standard_columns(data, context)
 
     validation_utilities.check_value_columns_boundary(data, boundary_value=VALID_INCIDENCE_RANGE[0],
                                                       boundary_type='lower', value_columns=['value'],
@@ -102,8 +120,8 @@ def _validate_incidence(data: pd.DataFrame, entity: Union[Cause, Sequela], locat
     _check_sex_restrictions(data, entity.restrictions.male_only, entity.restrictions.female_only, fill_value=0.0)
 
 
-def _validate_prevalence(data: pd.DataFrame, entity: Union[Cause, Sequela], location: str):
-    _validate_standard_columns(data, location)
+def _validate_prevalence(data: pd.DataFrame, entity: Union[Cause, Sequela], context: SimulationValidationContext):
+    _validate_standard_columns(data, context)
 
     validation_utilities.check_value_columns_boundary(data, boundary_value=VALID_PREVALENCE_RANGE[0],
                                                       boundary_type='lower', value_columns=['value'],
@@ -116,10 +134,10 @@ def _validate_prevalence(data: pd.DataFrame, entity: Union[Cause, Sequela], loca
     _check_sex_restrictions(data, entity.restrictions.male_only, entity.restrictions.female_only, fill_value=0.0)
 
 
-def _validate_birth_prevalence(data: pd.DataFrame, entity: Union[Cause, Sequela], location: str):
-    _validate_location_column(data, location)
+def _validate_birth_prevalence(data: pd.DataFrame, entity: Union[Cause, Sequela], context: SimulationValidationContext):
+    _validate_location_column(data, context)
     _validate_sex_column(data)
-    _validate_year_columns(data)
+    _validate_year_columns(data, context)
     _validate_draw_column(data)
     _validate_value_column(data)
 
@@ -133,8 +151,8 @@ def _validate_birth_prevalence(data: pd.DataFrame, entity: Union[Cause, Sequela]
     _check_sex_restrictions(data, entity.restrictions.male_only, entity.restrictions.female_only, fill_value=0.0)
 
 
-def _validate_disability_weight(data: pd.DataFrame, entity: Union[Cause, Sequela], location: str):
-    _validate_standard_columns(data, location)
+def _validate_disability_weight(data: pd.DataFrame, entity: Union[Cause, Sequela], context: SimulationValidationContext):
+    _validate_standard_columns(data, context)
 
     validation_utilities.check_value_columns_boundary(data, boundary_value=VALID_DISABILITY_WEIGHT_RANGE[0],
                                                       boundary_type='lower', value_columns=['value'],
@@ -147,8 +165,8 @@ def _validate_disability_weight(data: pd.DataFrame, entity: Union[Cause, Sequela
     _check_sex_restrictions(data, entity.restrictions.male_only, entity.restrictions.female_only, fill_value=0.0)
 
 
-def _validate_remission(data: pd.DataFrame, entity: Cause, location: str):
-    _validate_standard_columns(data, location)
+def _validate_remission(data: pd.DataFrame, entity: Cause, context: SimulationValidationContext):
+    _validate_standard_columns(data, context)
 
     validation_utilities.check_value_columns_boundary(data, boundary_value=VALID_REMISSION_RANGE[0],
                                                       boundary_type='lower', value_columns=['value'],
@@ -161,8 +179,8 @@ def _validate_remission(data: pd.DataFrame, entity: Cause, location: str):
     _check_sex_restrictions(data, entity.restrictions.male_only, entity.restrictions.female_only, fill_value=0.0)
 
 
-def _validate_cause_specific_mortality(data: pd.DataFrame, entity: Cause, location: str):
-    _validate_standard_columns(data, location)
+def _validate_cause_specific_mortality(data: pd.DataFrame, entity: Cause, context: SimulationValidationContext):
+    _validate_standard_columns(data, context)
 
     validation_utilities.check_value_columns_boundary(data, boundary_value=VALID_CAUSE_SPECIFIC_MORTALITY_RANGE[0],
                                                       boundary_type='lower', value_columns=['value'],
@@ -175,8 +193,8 @@ def _validate_cause_specific_mortality(data: pd.DataFrame, entity: Cause, locati
     _check_sex_restrictions(data, entity.restrictions.male_only, entity.restrictions.female_only, fill_value=0.0)
 
 
-def _validate_excess_mortality(data: pd.DataFrame, entity: Cause, location: str):
-    _validate_standard_columns(data, location)
+def _validate_excess_mortality(data: pd.DataFrame, entity: Cause, context: SimulationValidationContext):
+    _validate_standard_columns(data, context)
 
     validation_utilities.check_value_columns_boundary(data, boundary_value=VALID_EXCESS_MORT_RANGE[0],
                                                       boundary_type='lower', value_columns=['value'],
@@ -189,23 +207,20 @@ def _validate_excess_mortality(data: pd.DataFrame, entity: Cause, location: str)
     _check_sex_restrictions(data, entity.restrictions.male_only, entity.restrictions.female_only, fill_value=0.0)
 
 
-def _validate_case_fatality(data, entity, location):
-    raise NotImplementedError()
-
-
 def _validate_exposure(data: pd.DataFrame, entity: Union[RiskFactor, CoverageGap, AlternativeRiskFactor],
-                       location: str):
+                       context: SimulationValidationContext):
     is_continuous = entity.distribution in ['normal', 'lognormal', 'ensemble']
     is_categorical = entity.distribution in ['dichotomous', 'ordered_polytomous', 'unordered_polytomous']
 
     if is_continuous:
         if set(data.parameter) != {"continuous"}:
-            raise DataTransformationError("Continuous exposure data should contain 'continuous' in the parameter column.")
+            raise DataTransformationError("Continuous exposure data should contain "
+                                          "'continuous' in the parameter column.")
         valid_kwd = 'continuous'
     elif is_categorical:
         if set(data.parameter) != set(entity.categories.to_dict()):  # to_dict removes None
-            raise DataTransformationError("Categorical exposure data does not contain all categories in the parameter "
-                                      "column.")
+            raise DataTransformationError("Categorical exposure data does not contain all "
+                                          "categories in the parameter column.")
         valid_kwd = 'categorical'
     else:
         raise NotImplementedError()
@@ -218,7 +233,7 @@ def _validate_exposure(data: pd.DataFrame, entity: Union[RiskFactor, CoverageGap
                                                       error=DataTransformationError)
 
     cats = data.groupby('parameter')
-    cats.apply(_validate_standard_columns, location)
+    cats.apply(_validate_standard_columns, context)
 
     if is_categorical:
         non_categorical_columns = list(set(data.columns).difference({'parameter', 'value'}))
@@ -230,8 +245,8 @@ def _validate_exposure(data: pd.DataFrame, entity: Union[RiskFactor, CoverageGap
 
 
 def _validate_exposure_standard_deviation(data: pd.DataFrame, entity: Union[RiskFactor, AlternativeRiskFactor],
-                                          location: str):
-    _validate_standard_columns(data, location)
+                                          context: SimulationValidationContext):
+    _validate_standard_columns(data, context)
 
     validation_utilities.check_value_columns_boundary(data, boundary_value=VALID_EXPOSURE_SD_RANGE[0],
                                                       boundary_type='lower', value_columns=['value'],
@@ -245,8 +260,8 @@ def _validate_exposure_standard_deviation(data: pd.DataFrame, entity: Union[Risk
 
 
 def _validate_exposure_distribution_weights(data: pd.DataFrame, entity: Union[RiskFactor, AlternativeRiskFactor],
-                                            location: str):
-    _validate_demographic_columns(data, location)
+                                            context: SimulationValidationContext):
+    _validate_demographic_columns(data, context)
     _validate_value_column(data)
 
     validation_utilities.check_value_columns_boundary(data, boundary_value=VALID_EXPOSURE_DIST_WEIGHTS_RANGE[0],
@@ -265,9 +280,9 @@ def _validate_exposure_distribution_weights(data: pd.DataFrame, entity: Union[Ri
     _check_sex_restrictions(data, entity.restrictions.male_only, entity.restrictions.female_only, fill_value=0.0)
 
 
-def _validate_relative_risk(data: pd.DataFrame, entity: Union[RiskFactor, CoverageGap], location: str):
+def _validate_relative_risk(data: pd.DataFrame, entity: Union[RiskFactor, CoverageGap], context: SimulationValidationContext):
     risk_relationship = data.groupby(['affected_entity', 'affected_measure', 'parameter'])
-    risk_relationship.apply(_validate_standard_columns, location)
+    risk_relationship.apply(_validate_standard_columns, context)
 
     is_continuous = entity.distribution in ['normal', 'lognormal', 'ensemble']
     is_categorical = entity.distribution in ['dichotomous', 'ordered_polytomous', 'unordered_polytomous']
@@ -302,9 +317,9 @@ def _validate_relative_risk(data: pd.DataFrame, entity: Union[RiskFactor, Covera
     _check_sex_restrictions(data, entity.restrictions.male_only, entity.restrictions.female_only, fill_value=1.0)
 
 
-def _validate_population_attributable_fraction(data: pd.DataFrame, entity: Union[RiskFactor, Etiology], location: str):
+def _validate_population_attributable_fraction(data: pd.DataFrame, entity: Union[RiskFactor, Etiology], context: SimulationValidationContext):
     risk_relationship = data.groupby(['affected_entity', 'affected_measure'])
-    risk_relationship.apply(_validate_standard_columns, location)
+    risk_relationship.apply(_validate_standard_columns, context)
 
     validation_utilities.check_value_columns_boundary(data, boundary_value=VALID_PAF_RANGE[0],
                                                       boundary_type='lower', value_columns=['value'],
@@ -317,27 +332,27 @@ def _validate_population_attributable_fraction(data: pd.DataFrame, entity: Union
     _check_sex_restrictions(data, entity.restrictions.male_only, entity.restrictions.female_only, fill_value=0.0)
 
 
-def _validate_mediation_factors(data, entity, location):
+def _validate_mediation_factors(data: pd.DataFrame, entity: RiskFactor, context: SimulationValidationContext):
     raise NotImplementedError()
 
 
-def _validate_estimate(data: pd.DataFrame, entity: Covariate, location: str):
+def _validate_estimate(data: pd.DataFrame, entity: Covariate, context: SimulationValidationContext):
     cols = ['location', 'year_start', 'year_end']
-    _validate_location_column(data, location)
+    _validate_location_column(data, context)
     if entity.by_sex:
         _validate_sex_column(data)
         cols += ['sex']
     if entity.by_age:
         _validate_age_columns(data)
         cols += ['age_group_start', 'age_group_end']
-    _validate_year_columns(data)
+    _validate_year_columns(data, context)
     _validate_value_column(data)
 
     data.groupby(cols).apply(_check_covariate_values)
 
 
-def _validate_cost(data: pd.DataFrame, entity: Union[HealthTechnology, HealthcareEntity], location: str):
-    _validate_standard_columns(data, location)
+def _validate_cost(data: pd.DataFrame, entity: Union[HealthTechnology, HealthcareEntity], context: SimulationValidationContext):
+    _validate_standard_columns(data, context)
     validation_utilities.check_value_columns_boundary(data, VALID_COST_RANGE[0], 'lower',
                                                       value_columns=['value'], inclusive=True,
                                                       error=DataTransformationError)
@@ -346,8 +361,8 @@ def _validate_cost(data: pd.DataFrame, entity: Union[HealthTechnology, Healthcar
                                                       error=DataTransformationError)
 
 
-def _validate_utilization(data: pd.DataFrame, entity: HealthcareEntity, location: str):
-    _validate_standard_columns(data, location)
+def _validate_utilization(data: pd.DataFrame, entity: HealthcareEntity, context: SimulationValidationContext):
+    _validate_standard_columns(data, context)
     validation_utilities.check_value_columns_boundary(data, VALID_UTILIZATION_RANGE[0], 'lower',
                                                       value_columns=['value'], inclusive=True,
                                                       error=DataTransformationError)
@@ -356,8 +371,8 @@ def _validate_utilization(data: pd.DataFrame, entity: HealthcareEntity, location
                                                       error=DataTransformationError)
 
 
-def _validate_structure(data: pd.DataFrame, entity: NamedTuple, location: str):
-    _validate_demographic_columns(data, location)
+def _validate_structure(data: pd.DataFrame, entity: NamedTuple, context: SimulationValidationContext):
+    _validate_demographic_columns(data, context)
     _validate_value_column(data)
 
     validation_utilities.check_value_columns_boundary(data, VALID_POPULATION_RANGE[0], 'lower',
@@ -368,9 +383,10 @@ def _validate_structure(data: pd.DataFrame, entity: NamedTuple, location: str):
                                                       error=DataTransformationError)
 
 
-def _validate_theoretical_minimum_risk_life_expectancy(data: pd.DataFrame, entity: NamedTuple, location: str):
+def _validate_theoretical_minimum_risk_life_expectancy(data: pd.DataFrame, entity: NamedTuple, context: SimulationValidationContext):
     if 'age_group_start' not in data.columns or 'age_group_end' not in data.columns:
-        raise DataTransformationError("Age data must be contained in columns named 'age_group_start' and 'age_group_end'.")
+        raise DataTransformationError("Age data must be contained in columns named "
+                                      "'age_group_start' and 'age_group_end'.")
 
     age_min, age_max = 0, 110
     if data.age_group_start.min() > age_min or data.age_group_start.max() < age_max:
@@ -387,12 +403,12 @@ def _validate_theoretical_minimum_risk_life_expectancy(data: pd.DataFrame, entit
         raise DataTransformationError('Life expectancy data is not monotonically decreasing over age.')
 
 
-def _validate_age_bins(data: pd.DataFrame, entity: NamedTuple, location: str):
+def _validate_age_bins(data: pd.DataFrame, entity: NamedTuple, context: SimulationValidationContext):
     _validate_age_columns(data)
 
 
-def _validate_demographic_dimensions(data: pd.DataFrame, entity: NamedTuple, location: str):
-    _validate_demographic_columns(data, location)
+def _validate_demographic_dimensions(data: pd.DataFrame, entity: NamedTuple, context: SimulationValidationContext):
+    _validate_demographic_columns(data, context)
 
 
 #############
@@ -400,17 +416,17 @@ def _validate_demographic_dimensions(data: pd.DataFrame, entity: NamedTuple, loc
 #############
 
 
-def _validate_standard_columns(data: pd.DataFrame, location: str):
-    _validate_demographic_columns(data, location)
+def _validate_standard_columns(data: pd.DataFrame, context: SimulationValidationContext):
+    _validate_demographic_columns(data, context)
     _validate_draw_column(data)
     _validate_value_column(data)
 
 
-def _validate_demographic_columns(data: pd.DataFrame, location: str):
-    _validate_location_column(data, location)
+def _validate_demographic_columns(data: pd.DataFrame, context: SimulationValidationContext):
+    _validate_location_column(data, context)
     _validate_sex_column(data)
     _validate_age_columns(data)
-    _validate_year_columns(data)
+    _validate_year_columns(data, context)
 
 
 def _validate_draw_column(data: pd.DataFrame):
@@ -421,11 +437,11 @@ def _validate_draw_column(data: pd.DataFrame):
         raise DataTransformationError('Draw must contain [0, 999].')
 
 
-def _validate_location_column(data: pd.DataFrame, location: str):
+def _validate_location_column(data: pd.DataFrame, context: SimulationValidationContext):
     if 'location' not in data.columns:
         raise DataTransformationError("Location data must be contained in a column named 'location'.")
 
-    if len(data['location'].unique()) != 1 or data['location'].unique()[0] != location:
+    if len(data['location'].unique()) != 1 or data['location'].unique()[0] != context['location']:
         raise DataTransformationError('Location must contain a single value that matches specified location.')
 
 
@@ -439,7 +455,8 @@ def _validate_sex_column(data: pd.DataFrame):
 
 def _validate_age_columns(data: pd.DataFrame):
     if 'age_group_start' not in data.columns or 'age_group_end' not in data.columns:
-        raise DataTransformationError("Age data must be contained in columns named 'age_group_start' and 'age_group_end'.")
+        raise DataTransformationError("Age data must be contained in columns named"
+                                      " 'age_group_start' and 'age_group_end'.")
 
     expected_ages = utilities.get_age_bins()[['age_group_start', 'age_group_end']].sort_values(['age_group_start',
                                                                                                 'age_group_end'])
@@ -452,11 +469,11 @@ def _validate_age_columns(data: pd.DataFrame):
         raise DataTransformationError('Age_group_start and age_group_end must contain all gbd age groups.')
 
 
-def _validate_year_columns(data: pd.DataFrame):
+def _validate_year_columns(data: pd.DataFrame, context: SimulationValidationContext):
     if 'year_start' not in data.columns or 'year_end' not in data.columns:
         raise DataTransformationError("Year data must be contained in columns named 'year_start', and 'year_end'.")
 
-    expected_years = utilities.get_annual_year_bins().sort_values(['year_start', 'year_end'])
+    expected_years = context['estimation_years'].sort_values(['year_start', 'year_end'])
     year_block = (data[['year_start', 'year_end']]
                   .drop_duplicates()
                   .sort_values(['year_start', 'year_end'])
@@ -503,5 +520,6 @@ def _check_covariate_values(data: pd.DataFrame):
     # allow the case where lower = mean = upper = 0 b/c of things like age
     # specific fertility rate where all estimates are 0 for young age groups
     if np.all(data.value != 0) and not np.all(lower < mean < upper):
-        raise DataTransformationError('Covariate data contains demographic groups for which the estimates for lower, mean, '
-                                  'and upper values are not all 0 and it is not the case that lower < mean < upper. ')
+        raise DataTransformationError('Covariate data contains demographic groups for which the '
+                                      'estimates for lower, mean, and upper values are not all 0 '
+                                      'and it is not the case that lower < mean < upper. ')


### PR DESCRIPTION
Parts of this PR are provisional.  In particular, core's dependence on `gbd`.  I just needed a shim to split the work into separate PRs.  Things to pay attention to:

- Every function in core needs to have an entry in the top level dictionary.  I missed it when exposure age groups came in.
- ``get_demographic_dimensions`` take an additional kwarg.  There are two use cases for core functions: they get called from the top level ``get_data`` or they get called directly by other core functions.  I think the kwarg thing is fine beyond the standard entity and location id arguments given defaults that would produce data that makes sense to an external user.
- The validation context.  This is a light wrapper around a dict.  I'll probably switch it in the next pr to actually inherit from ``UserDict`` if that seems reasonably easy.  It's constructed from context args passed to the main validate for simulation function.  It might be nice to have this as more of a global switch or as a context manager directly.  I'm thinking for the use case where someone wants to build an artifact with different age or year bins but still validate things well.  Could use some thoughts on this.