### PR TITLE
Feature/handle protective

### DIFF
--- a/src/vivarium_inputs/globals.py
+++ b/src/vivarium_inputs/globals.py
@@ -1,5 +1,5 @@
 """Global constants, errors, and module imports for inputs processing."""
-from gbd_mapping import ModelableEntity
+from gbd_mapping import ModelableEntity, causes
 
 
 # The purpose of this import block is to mask the dependency on internal
@@ -112,6 +112,10 @@ SEXES = {'Male': 1,
 # Mapping of non-standard age group ids sometimes found in GBD data
 SPECIAL_AGES = {'all_ages': 22,
                 'age_standardized': 27}
+
+PROTECTIVE_CAUSE_RISK_PAIRS = {
+    'high_body_mass_index_in_adults': [causes.neoplasms, causes.breast_cancer]
+}
 
 
 class Population(ModelableEntity):

--- a/src/vivarium_inputs/validation/raw.py
+++ b/src/vivarium_inputs/validation/raw.py
@@ -22,6 +22,9 @@ MAX_INCIDENCE = 10
 MAX_REMISSION = 365/3
 MAX_CATEG_REL_RISK = 20
 MAX_CONT_REL_RISK = 5
+MAX_PAF = 1
+MIN_PAF = 0
+MIN_PROTECTIVE_PAF = -1
 MAX_UTILIZATION = 50
 MAX_LIFE_EXP = 90
 MAX_POP = 100_000_000
@@ -850,14 +853,14 @@ def validate_population_attributable_fraction(data: pd.DataFrame, entity: Union[
         protected_causes = [cause.gbd_id for cause in PROTECTIVE_CAUSE_RISK_PAIRS[entity.name]]
         protective = data.loc[data.cause_id.isin(protected_causes)]
         non_protective = data.loc[data.index.difference(protective.index)]
-        check_value_columns_boundary(protective, -1.0, 'lower', value_columns=DRAW_COLUMNS, inclusive=True,
+        check_value_columns_boundary(protective, MIN_PROTECTIVE_PAF, 'lower', value_columns=DRAW_COLUMNS, inclusive=True,
                                      error=DataAbnormalError)
-        check_value_columns_boundary(non_protective, 0, 'lower', value_columns=DRAW_COLUMNS, inclusive=True,
+        check_value_columns_boundary(non_protective, MIN_PAF, 'lower', value_columns=DRAW_COLUMNS, inclusive=True,
                                      error=DataAbnormalError)
     else:
-        check_value_columns_boundary(data, 0, 'lower', value_columns=DRAW_COLUMNS, inclusive=True, error=DataAbnormalError)
+        check_value_columns_boundary(data, MIN_PAF, 'lower', value_columns=DRAW_COLUMNS, inclusive=True, error=DataAbnormalError)
 
-    check_value_columns_boundary(data, 1, 'upper', value_columns=DRAW_COLUMNS, inclusive=True, error=DataAbnormalError)
+    check_value_columns_boundary(data, MAX_PAF, 'upper', value_columns=DRAW_COLUMNS, inclusive=True, error=DataAbnormalError)
 
     for c_id in data.cause_id:
         cause = [c for c in causes if c.gbd_id == c_id][0]


### PR DESCRIPTION
This PR handles the protective relationship between risk factors and causes. It introduces a global dict mapping risk_factor names to cause entities (and also lifts PAFs constants to globals at the top in raw.py). This is used when validating PAF values to alter the acceptable minimum, in both the raw and the simulation validators.

Incidentally, breast cancer and BMI have a contentious relationship, the protective effect is potentially real. I found that interesting.

It would be nice to make the gbd entities hashable so I could stick the risk_factor in directly as the key, but that's for another time.