### PR TITLE
support relative_risk_scalar in artifact loaders

### DIFF
--- a/src/vivarium_inputs/data_artifact/loaders.py
+++ b/src/vivarium_inputs/data_artifact/loaders.py
@@ -26,7 +26,8 @@ def loader(entity_key: EntityKey, location: str, modeled_causes: Set[str], all_m
             "getter": get_risk_data,
             "measures": ["affected_causes", "affected_risk_factors", "restrictions", "distribution",
                          "exposure_parameters", "categories", "tmred", "exposure", "exposure_standard_deviation",
-                         "relative_risk", "population_attributable_fraction", "exposure_distribution_weights"],
+                         "relative_risk", "relative_risk_scalar", "population_attributable_fraction",
+                         "exposure_distribution_weights"],
         },
         "alternative_risk_factor": {
             "mapping": alternative_risk_factors,
@@ -107,8 +108,8 @@ def get_cause_data(cause, measure, location, _):
 
 
 def get_risk_data(risk, measure, location, modeled_causes):
-    if measure in ["affected_causes", "affected_risk_factors", "restrictions",
-                   "distribution", "exposure_parameters", "categories", "tmred"]:
+    if measure in ["affected_causes", "affected_risk_factors", "restrictions", "distribution",
+                   "exposure_parameters", "categories", "tmred", "relative_risk_scalar"]:
         data = get_risk_metadata(risk, measure, modeled_causes)
     else:
         data = get_measure(risk, measure, location)

--- a/src/vivarium_inputs/data_artifact/loaders.py
+++ b/src/vivarium_inputs/data_artifact/loaders.py
@@ -25,16 +25,16 @@ def loader(entity_key: EntityKey, location: str, modeled_causes: Set[str], all_m
             "mapping": risk_factors,
             "getter": get_risk_data,
             "measures": ["affected_causes", "affected_risk_factors", "restrictions", "distribution",
-                         "exposure_parameters", "categories", "tmred", "exposure", "exposure_standard_deviation",
+                         "categories", "tmred", "exposure", "exposure_standard_deviation",
                          "relative_risk", "relative_risk_scalar", "population_attributable_fraction",
                          "exposure_distribution_weights"],
         },
         "alternative_risk_factor": {
             "mapping": alternative_risk_factors,
             "getter": get_risk_data,
-            "measures": ["affected_causes", "affected_risk_factors", "restrictions", "distribution",
-                         "exposure_parameters", "categories", "tmred", "exposure", "exposure_standard_deviation",
-                         "relative_risk", "population_attributable_fraction", "exposure_distribution_weights"],
+            "measures": ["affected_causes", "affected_risk_factors", "restrictions", "distribution", "exposure",
+                         "exposure_standard_deviation", "relative_risk", "population_attributable_fraction",
+                         "exposure_distribution_weights"],
         },
         "sequela": {
             "mapping": sequelae,
@@ -109,7 +109,7 @@ def get_cause_data(cause, measure, location, _):
 
 def get_risk_data(risk, measure, location, modeled_causes):
     if measure in ["affected_causes", "affected_risk_factors", "restrictions", "distribution",
-                   "exposure_parameters", "categories", "tmred", "relative_risk_scalar"]:
+                   "categories", "tmred", "relative_risk_scalar"]:
         data = get_risk_metadata(risk, measure, modeled_causes)
     else:
         data = get_measure(risk, measure, location)
@@ -223,7 +223,7 @@ def get_cause_metadata(entity, field):
 
 
 def get_risk_metadata(risk, measure, modeled_causes):
-    if measure in ["restrictions", "exposure_parameters", "categories", "tmred"]:
+    if measure in ["restrictions", "categories", "tmred"]:
         if risk[measure] is not None:
             data = risk[measure].to_dict()
         else:

--- a/src/vivarium_inputs/data_artifact/loaders.py
+++ b/src/vivarium_inputs/data_artifact/loaders.py
@@ -33,8 +33,7 @@ def loader(entity_key: EntityKey, location: str, modeled_causes: Set[str], all_m
             "mapping": alternative_risk_factors,
             "getter": get_risk_data,
             "measures": ["affected_causes", "affected_risk_factors", "restrictions", "distribution", "exposure",
-                         "exposure_standard_deviation", "relative_risk", "population_attributable_fraction",
-                         "exposure_distribution_weights"],
+                         "exposure_standard_deviation", "exposure_distribution_weights"],
         },
         "sequela": {
             "mapping": sequelae,


### PR DESCRIPTION
This is the second step to getting relative_risk_scalar into an artifact -- identifying it as a key that can be loaded. In the map it is a scalar() type 