### PR TITLE
handle case where seq does not have prevalence for dw calc for a cause

### DIFF
--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -6,7 +6,8 @@ import pandas as pd
 import numpy as np
 
 from vivarium_inputs import utilities, extract, utility_data
-from vivarium_inputs.globals import InvalidQueryError, DRAW_COLUMNS, DEMOGRAPHIC_COLUMNS, MEASURES, SEXES, Population
+from vivarium_inputs.globals import (InvalidQueryError, DEMOGRAPHIC_COLUMNS, MEASURES, SEXES,
+                                     Population, DataDoesNotExistError)
 from vivarium_inputs.mapping_extension import AlternativeRiskFactor, HealthcareEntity, HealthTechnology
 
 
@@ -102,7 +103,11 @@ def get_disability_weight(entity: Union[Cause, Sequela], location_id: int) -> pd
         data = data.set_index(DEMOGRAPHIC_COLUMNS + ['draw'])
         if entity.sequelae:
             for sequela in entity.sequelae:
-                prevalence = get_prevalence(sequela, location_id).set_index(DEMOGRAPHIC_COLUMNS + ['draw'])
+                try:
+                    prevalence = get_prevalence(sequela, location_id).set_index(DEMOGRAPHIC_COLUMNS + ['draw'])
+                except DataDoesNotExistError:
+                    # sequela prevalence does not exist so no point continuing with this sequela
+                    continue
                 disability = get_disability_weight(sequela, location_id)
                 disability['location_id'] = location_id
                 disability = disability.set_index(DEMOGRAPHIC_COLUMNS + ['draw'])


### PR DESCRIPTION
this isn't the bug you were hitting @halfhorst  - still looking into that but it's another problematic case I hit when I was looking for that one. Basically, if we have a sequela that doesn't have prevalence, it can raise an error and break the dw calc for the cause it belongs to. 