### PR TITLE
Bugfix/exp validator cat risk

### DIFF
--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -591,7 +591,7 @@ def check_sex_restrictions(data: pd.DataFrame, male_only: bool, female_only: boo
         outside = data[data.sex == 'Male']
         sex = 'female'
     if outside is not None:
-        if (entity.kind in ['risk_factor', 'alternative_risk_factor'] and
+        if entity is not None and (entity.kind in ['risk_factor', 'alternative_risk_factor'] and
                 entity.distribution in ['dichotomous', 'ordered_polytomous', 'unordered_polytomous']):
             _check_cat_risk_fill_values(outside, entity, fill_value, 'sex')
 

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -281,7 +281,7 @@ def validate_exposure(data: pd.DataFrame, entity: Union[RiskFactor, CoverageGap,
         check_age_restrictions(data, entity, rest_type='outer', fill_value={'exposed': 0.0, 'unexposed': 1.0},
                                context=context)
         check_sex_restrictions(data, entity.restrictions.male_only, entity.restrictions.female_only,
-                               fill_value={'exposed': 0.0, 'unexposed': 1.0})
+                               fill_value={'exposed': 0.0, 'unexposed': 1.0}, entity=entity)
 
 
 def validate_exposure_standard_deviation(data: pd.DataFrame, entity: Union[RiskFactor, AlternativeRiskFactor],


### PR DESCRIPTION
in core we fill categorical exposure data with two values: 1 for the tmrel cat and 0 for all others but we were only checking the single value 0 in the sim validator so it was failing for every categorical risk where we had to fill data