### PR TITLE
handle check age/sex restrictions for cont risk properly

### DIFF
--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -605,7 +605,6 @@ def check_sex_restrictions(data: pd.DataFrame, male_only: bool, female_only: boo
 
 def _check_cat_risk_fill_values(outside_data: pd.DataFrame, entity: Union[RiskFactor, AlternativeRiskFactor],
                                 fill_value: Dict[str, float], restriction: str):
-
     tmrel_cat = sorted(list(entity.categories.to_dict()), key=lambda x: int(x[3:]))[-1]
     outside_unexposed = outside_data[outside_data.parameter == tmrel_cat]
     outside_exposed = outside_data[outside_data.parameter != tmrel_cat]

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -575,7 +575,8 @@ def check_age_restrictions(data: pd.DataFrame, entity: ModelableEntity, rest_typ
     outside = data.loc[(data.age_group_start < age_start) | (data.age_group_end > age_end)]
 
     if (entity.kind in ['risk_factor', 'alternative_risk_factor'] and
-            entity.distribution in ['dichotomous', 'ordered_polytomous', 'unordered_polytomous']):
+            entity.distribution in ['dichotomous', 'ordered_polytomous', 'unordered_polytomous'] and
+            isinstance(fill_value, dict)):
         _check_cat_risk_fill_values(outside, entity, fill_value, 'age')
 
     elif not outside.empty and (outside.value != fill_value).any():
@@ -593,7 +594,8 @@ def check_sex_restrictions(data: pd.DataFrame, male_only: bool, female_only: boo
         sex = 'female'
     if outside is not None:
         if entity is not None and (entity.kind in ['risk_factor', 'alternative_risk_factor'] and
-                entity.distribution in ['dichotomous', 'ordered_polytomous', 'unordered_polytomous']):
+                                   entity.distribution in ['dichotomous', 'ordered_polytomous', 'unordered_polytomous']
+                                   and isinstance(fill_value, dict)):
             _check_cat_risk_fill_values(outside, entity, fill_value, 'sex')
 
         elif (outside.value != fill_value).any():
@@ -603,15 +605,16 @@ def check_sex_restrictions(data: pd.DataFrame, male_only: bool, female_only: boo
 
 def _check_cat_risk_fill_values(outside_data: pd.DataFrame, entity: Union[RiskFactor, AlternativeRiskFactor],
                                 fill_value: Dict[str, float], restriction: str):
+
     tmrel_cat = sorted(list(entity.categories.to_dict()), key=lambda x: int(x[3:]))[-1]
     outside_unexposed = outside_data[outside_data.parameter == tmrel_cat]
     outside_exposed = outside_data[outside_data.parameter != tmrel_cat]
     if not outside_unexposed.empty and (outside_unexposed.value != fill_value['unexposed']).any():
         raise DataTransformationError(f'{restriction.capitalize()} restrictions for TMREL cat are violated by a '
-                                      f'value other than fill={fill_value["unexposed"]}')
+                                      f'value other than fill={fill_value["unexposed"]}.')
     if not outside_exposed.empty and (outside_exposed.value != fill_value['exposed']).any():
-        raise DataTransformationError(f'{restriction.capitalize()} restrictions for non-TMREL categories are violated by a '
-                                      f'value other than fill={fill_value["exposed"]}')
+        raise DataTransformationError(f'{restriction.capitalize()} restrictions for non-TMREL categories are violated '
+                                      f'by a value other than fill={fill_value["exposed"]}.')
 
 
 def check_covariate_values(data: pd.DataFrame):


### PR DESCRIPTION
solves a bug where the RR and other validators were using the same check age/sex restriction functions but only the exp had the dict but the check wasn't complete. 