### PR TITLE
Bugfix/filter seq dw rest

### DIFF
--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -122,7 +122,8 @@ def get_disability_weight(entity: Union[Cause, Sequela], location_id: int) -> pd
             data = extract.extract_data(entity, 'disability_weight', location_id)
             data = utilities.normalize(data)
             cause = [c for c in causes if c.sequelae and entity in c.sequelae][0]
-            data = utilities.filter_data_by_restrictions(data, cause,  'yld', utility_data.get_age_group_ids())
+            data = utilities.clear_disability_weight_outside_restrictions(data, cause, 0.0,
+                                                                          utility_data.get_age_group_ids())
             data = utilities.reshape(data)
 
     return data

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -120,9 +120,9 @@ def get_disability_weight(entity: Union[Cause, Sequela], location_id: int) -> pd
             data['value'] = 0.0
         else:
             data = extract.extract_data(entity, 'disability_weight', location_id)
+            data = utilities.normalize(data)
             cause = [c for c in causes if c.sequelae and entity in c.sequelae][0]
             data = utilities.filter_data_by_restrictions(data, cause,  'yld', utility_data.get_age_group_ids())
-            data = utilities.normalize(data)
             data = utilities.reshape(data)
 
     return data

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -120,6 +120,8 @@ def get_disability_weight(entity: Union[Cause, Sequela], location_id: int) -> pd
             data['value'] = 0.0
         else:
             data = extract.extract_data(entity, 'disability_weight', location_id)
+            cause = [c for c in causes if c.sequelae and entity in c.sequelae][0]
+            data = utilities.filter_data_by_restrictions(data, cause,  'yld', utility_data.get_age_group_ids())
             data = utilities.normalize(data)
             data = utilities.reshape(data)
 


### PR DESCRIPTION
so we were essentially clearing the disability weight outside of cause restrictions to 0 when we were aggregating over sequela for a cause because we were multiplying by the cause prevalence which was already set to 0 outside cause restrictions. We weren't doing this for pulling just a single sequela disability weigh though - which was what was breaking in the sanofi smoke test yesterday. 