### PR TITLE
Bugfix/multi build artifact

### DIFF
--- a/src/vivarium_inputs/data_artifact/aggregation.py
+++ b/src/vivarium_inputs/data_artifact/aggregation.py
@@ -68,9 +68,9 @@ def aggregate(artifacts: [Artifact], artifact_path: str) -> Artifact:
             valid_artifacts.append(a)
             valid_locations.extend(a.load('metadata.locations'))
         else:
-            logging.warning(f'Missing_keys: {keyspace_set.difference(set(a.load("metadata.keyspace")))} '
-                            f'for location:{a.load("metadata.locations")} All artifacts not aggregated'
-                            f'will be stored in {artifact_path}/broken_artifacts.', ArtifactAggregationWarning)
+            warnings.warn(f'Missing_keys: {keyspace_set.difference(set(a.load("metadata.keyspace")))} '
+                          f'for location:{a.load("metadata.locations")} All artifacts not aggregated'
+                          f'will be stored in {artifact_path}/broken_artifacts.', ArtifactAggregationWarning)
 
     artifact = Artifact(artifact_path.as_posix())
     artifact.write("metadata.locations", valid_locations)

--- a/src/vivarium_inputs/data_artifact/aggregation.py
+++ b/src/vivarium_inputs/data_artifact/aggregation.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Set
 
 from vivarium_public_health.dataset_manager import Artifact, ArtifactException, get_location_term
-from vivarium_inputs.data_artifact.utilities import get_versions
+from vivarium_inputs.data_artifact.utilities import get_versions, setup_logging
 
 
 _log = logging.getLogger(__name__)
@@ -22,14 +22,16 @@ def unpack_arguments(parser, rawargs=None):
     parser.add_argument('--config_path', type=str, required=True)
     parser.add_argument('--output_root', type=str, required=True)
     parser.add_argument('--locations', nargs='+')
+    parser.add_argument('--verbose', action='store_true')
     args = parser.parse_args(rawargs)
 
     config_path = Path(args.config_path)
     locations = args.locations
     locations = [l.replace('_', ' ') for l in locations]
     output_root = args.output_root
+    verbose = args.verbose
 
-    return config_path, locations, output_root
+    return config_path, locations, output_root, verbose
 
 
 def aggregate(artifacts: [Artifact], artifact_path: str) -> Artifact:
@@ -56,6 +58,8 @@ def aggregate(artifacts: [Artifact], artifact_path: str) -> Artifact:
     if artifact_path.is_file():
         artifact_path.unlink()
 
+    logging.debug(f'Validating individual artifacts for the common keyspace.')
+
     locations = set().union(*[a.load('metadata.locations') for a in artifacts])
     keyspace_set = set().union(*[a.load('metadata.keyspace') for a in artifacts])
     valid_artifacts, valid_locations = [], []
@@ -64,17 +68,18 @@ def aggregate(artifacts: [Artifact], artifact_path: str) -> Artifact:
             valid_artifacts.append(a)
             valid_locations.extend(a.load('metadata.locations'))
         else:
-            warnings.warn(f'missing_keys: {keyspace_set.difference(set(a.load("metadata.keyspace")))} '
-                          f'for location:{a.load("metadata.locations")} All the artifacts not aggregated'
-                          f'will be stored in {artifact_path}/broken_artifacts.', ArtifactAggregationWarning)
+            logging.warning(f'Missing_keys: {keyspace_set.difference(set(a.load("metadata.keyspace")))} '
+                            f'for location:{a.load("metadata.locations")} All artifacts not aggregated'
+                            f'will be stored in {artifact_path}/broken_artifacts.', ArtifactAggregationWarning)
 
     artifact = Artifact(artifact_path.as_posix())
     artifact.write("metadata.locations", valid_locations)
     current_versions = get_versions()
 
     artifact.write("metadata.versions", current_versions)
-
-    for k in keyspace_set - set(METADATA):
+    keys_to_process = keyspace_set - set(METADATA)
+    for i, k in enumerate(keys_to_process):
+        logging.debug(f'Processing key {i+1} of {len(keys_to_process)}: {k}.')
         data = [a.load(k) for a in valid_artifacts]
         if isinstance(data[0], pd.DataFrame):
             if 'location' in data[0].columns:
@@ -86,6 +91,8 @@ def aggregate(artifacts: [Artifact], artifact_path: str) -> Artifact:
         else:
             assert np.all([d == data[0] for d in data])
             artifact.write(k, data[0])
+
+    logging.debug('Finished aggregating keys. Commencing cleanup of location-specific artifact.')
 
     # clean-up
     for loc in valid_locations:
@@ -103,6 +110,8 @@ def aggregate(artifacts: [Artifact], artifact_path: str) -> Artifact:
             f = artifact_path.parent/f'{artifact_path.stem}_{l}.hdf'
             f.rename(new_dir/f.name)
 
+    logging.debug('Aggregation cleanup finished.')
+
     return artifact
 
 
@@ -113,7 +122,9 @@ def main(rawargs=None):
         in the union of keyspaces.
     """
     parser = argparse.ArgumentParser()
-    config_path, locations, output = unpack_arguments(parser, rawargs)
+    config_path, locations, output, verbose = unpack_arguments(parser, rawargs)
+
+    setup_logging(output, verbose, 'aggregation', config_path, False)
 
     individual_artifacts = []
     for loc in locations:
@@ -122,8 +133,9 @@ def main(rawargs=None):
         individual_artifacts.append(Artifact(individual_path.as_posix()))
 
     artifact_path = f'{output}/{config_path.stem}.hdf'
-    _log.debug(f'{locations}')
+    logging.debug(f'Beginning aggregation for: {locations}.')
     if len(locations) == 1:
+        logging.debug(f'Processing location 1 of 1: {locations[0]}.')
         location = locations[0].replace(' ', '_').replace("'", "-")
         current_artifact = Path(output) / f'{config_path.stem}_{location}.hdf'
         current_artifact.rename(Path(artifact_path))
@@ -133,7 +145,7 @@ def main(rawargs=None):
 
 
 def disaggregate(config_name: str, output_root: str) -> Set:
-    """Disaggreagte the existing multi-location artifacts into the single
+    """Disaggregate the existing multi-location artifacts into the single
     location artifacts for appending. It is only called when the append flag
     is true. If the existing artifact was built under the different versions of
     relevant libraries from the versions of those at the moment when appending
@@ -161,8 +173,8 @@ def disaggregate(config_name: str, output_root: str) -> Set:
 
     if existing_artifact.load('metadata.versions') != get_versions():
         #  FIXME: For now we only warn and build from scratch. We need a smarter way to handle ths.
-        warnings.warn('Your artifact was built under the different versions and we cannot append it. It will be built '
-                      'from scratch', ArtifactAggregationWarning)
+        warnings.warn('Your artifact was built under different versions from those currently installed, '
+                      'so we cannot append to it. It will be built from scratch.', ArtifactAggregationWarning)
 
         initial_artifact_path.unlink()
         existing_locations = {}

--- a/src/vivarium_inputs/data_artifact/aggregation.py
+++ b/src/vivarium_inputs/data_artifact/aggregation.py
@@ -92,7 +92,7 @@ def aggregate(artifacts: [Artifact], artifact_path: str) -> Artifact:
             assert np.all([d == data[0] for d in data])
             artifact.write(k, data[0])
 
-    logging.debug('Finished aggregating keys. Commencing cleanup of location-specific artifact.')
+    logging.debug('Finished aggregating keys. Commencing cleanup of location-specific artifacts.')
 
     # clean-up
     for loc in valid_locations:

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -89,14 +89,16 @@ def multi_build_artifact(model_specification, locations, project, output_root, a
     """
 
     if len(set(locations)) > 15:
-        raise ValueError(f'We can make an artifact for upto 15 locations. You provide {len(set(locations))} locations')
+        raise ValueError(f'We can make an artifact for up to 15 locations. '
+                         f'You provided {len(set(locations))} locations.')
 
     if len(set(locations)) < 1:
-        raise ValueError('You should provide a list of locations for this aritfcat. You did not provide any')
+        raise ValueError('You must provide a list of locations for this artifact. You did not provide any.')
 
     config_path = pathlib.Path(model_specification).resolve()
     python_context_path = pathlib.Path(shutil.which("python")).resolve()
     script_path = pathlib.Path(__file__).resolve()
+    output_root = get_output_base(output_root)
 
     if append:
         click.secho('Pre-processing the existing artifact for appending. Please wait for the job submission messages. '

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -137,7 +137,7 @@ def multi_build_artifact(model_specification, locations, project, output_root, a
     locations = [l.replace("'", "-") for l in locations]
     aggregate_script = pathlib.Path(__file__).parent / 'aggregation.py'
     aggregate_args = f'--locations {" ".join(locations)} --output_root {output_root} ' \
-        f'--config_path {config_path} --verbose {verbose}'
+        f'--config_path {config_path} {"--verbose" if verbose else ""}'
     aggregate_job_name = f"{config_path.stem}_aggregate_artifacts"
     aggregate_command = build_submit_command(python_context_path, aggregate_job_name, 
                                              project, error_log_dir, f'{aggregate_script} {aggregate_args}', memory=35,

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -2,7 +2,6 @@ from bdb import BdbQuit
 import os
 import shutil
 import logging
-import getpass
 import pathlib
 import argparse
 import subprocess
@@ -15,6 +14,7 @@ from vivarium.interface.interactive import InteractiveContext
 from vivarium.config_tree import ConfigTree
 
 from vivarium_inputs.data_artifact.aggregation import disaggregate
+from vivarium_inputs.data_artifact import utilities
 
 
 @click.command()
@@ -98,12 +98,12 @@ def multi_build_artifact(model_specification, locations, project, output_root, a
     config_path = pathlib.Path(model_specification).resolve()
     python_context_path = pathlib.Path(shutil.which("python")).resolve()
     script_path = pathlib.Path(__file__).resolve()
-    output_root = get_output_base(output_root)
+    output_root = utilities.get_output_base(output_root)
 
     if append:
         click.secho('Pre-processing the existing artifact for appending. Please wait for the job submission messages. '
-                    'It may take long espeically if your aritfact already includes many locations inside. '
-                    'please DO NOT quit during the process', fg='blue')
+                    'It may take long, especially if your artifact already includes many locations. '
+                    'Please DO NOT QUIT during the process.', fg='blue')
         existing_locations = disaggregate(config_path.stem, output_root)
     else:
         existing_locations = {}
@@ -116,7 +116,7 @@ def multi_build_artifact(model_specification, locations, project, output_root, a
     if verbose:
         script_args += f" --verbose "
 
-    error_log_dir = _make_log_dir(output_root) if error_logs else None
+    error_log_dir = utilities.make_log_dir(output_root) if error_logs else None
     jids = list()
 
     existing_locations_jobs = {loc: f"{config_path.stem}_{loc}_build_artifact" for loc in existing_locations}
@@ -136,7 +136,8 @@ def multi_build_artifact(model_specification, locations, project, output_root, a
 
     locations = [l.replace("'", "-") for l in locations]
     aggregate_script = pathlib.Path(__file__).parent / 'aggregation.py'
-    aggregate_args = f'--locations {" ".join(locations)} --output_root {output_root} --config_path {config_path}'
+    aggregate_args = f'--locations {" ".join(locations)} --output_root {output_root} ' \
+        f'--config_path {config_path} --verbose {verbose}'
     aggregate_job_name = f"{config_path.stem}_aggregate_artifacts"
     aggregate_command = build_submit_command(python_context_path, aggregate_job_name, 
                                              project, error_log_dir, f'{aggregate_script} {aggregate_args}', memory,
@@ -290,8 +291,7 @@ def _build_artifact():
     parser.add_argument('--pdb', action='store_true')
     args = parser.parse_args()
 
-    _setup_logging(args.output_root, args.verbose, args.location,
-                   args.model_specification, args.append)
+    utilities.setup_logging(args.output_root, args.verbose, args.location, args.model_specification, args.append)
 
     try:
         main(args.model_specification, args.output_root, args.location, args.append)
@@ -410,76 +410,13 @@ def get_output_path(configuration_arg: str, output_root_arg: str,
 
     configuration_path = pathlib.Path(configuration_arg)
 
-    output_base = get_output_base(output_root_arg)
+    output_base = utilities.get_output_base(output_root_arg)
 
     if location_arg:
         output_path = output_base / (configuration_path.stem + f'_{location_arg}.hdf')
     else:
         output_path = output_base / (configuration_path.stem + '.hdf')
     return str(output_path)
-
-
-def get_output_base(output_root_arg: str) -> pathlib.Path:
-    """Resolve the correct output directory
-
-    Defaults to /ihme/scratch/users/{user}/vivarium_artifacts/
-    if no user passed output directory. Makes output directory
-    if doesn't already exist.
-
-    Parameters
-    ----------
-    output_root_arg
-        The output_root argument passed to the click executable
-
-    Returns
-    -------
-        A PathLike object containing the path to the output directory
-    """
-
-    if output_root_arg:
-        output_base = pathlib.Path(output_root_arg).resolve()
-    else:
-        output_base = (pathlib.Path('/share') / 'scratch' / 'users' /
-                       getpass.getuser() / 'vivarium_artifacts')
-
-    if not output_base.is_dir():
-        output_base.mkdir(parents=True)
-
-    return output_base
-
-
-def _make_log_dir(output_root):
-    output_log_dir = get_output_base(output_root) / 'logs'
-
-    if not output_log_dir.is_dir():
-        output_log_dir.mkdir()
-
-    return output_log_dir
-
-
-def _setup_logging(output_root, verbose, location,
-                   model_specification, append):
-    """ Setup logging to write to a file in the output directory
-
-    Log file named as {model_specification}_{location}_build_artifact.log
-    to match naming format of qsubbed jobs. File saved in output directory
-    (either passed by user or default)/logs. Raises error if that output
-    directory is not found.
-
-    """
-
-    output_log_dir = _make_log_dir(output_root)
-
-    log_level = logging.DEBUG if verbose else logging.ERROR
-    log_tag = f'_{location}' if location is not None else ''
-    spec_name = pathlib.Path(model_specification).resolve().stem
-    log_name = f'{output_log_dir}/{spec_name}{log_tag}_build_artifact.log'
-
-    logging.basicConfig(level=log_level,
-                        format='%(asctime)s %(levelname)-8s %(message)s',
-                        datefmt="%m-%d-%y %H:%M",
-                        filename=log_name,
-                        filemode='a' if append else 'w')
 
 
 if __name__ == "__main__":

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -141,7 +141,7 @@ def multi_build_artifact(model_specification, locations, project, output_root, a
     aggregate_job_name = f"{config_path.stem}_aggregate_artifacts"
     aggregate_command = build_submit_command(python_context_path, aggregate_job_name, 
                                              project, error_log_dir, f'{aggregate_script} {aggregate_args}', memory=35,
-                                             archive=True, queue='all.q', hold=True, jids=jids, slots=20)
+                                             archive=True, queue='all.q', hold=True, jids=jids, slots=15)
     submit_job(aggregate_command, aggregate_job_name)
 
 

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -66,7 +66,7 @@ def multi_build_artifact(model_specification, locations, project, output_root, a
     """
     multi_build_artifact is a program for building data artifacts on the cluster
     from a MODEL_SPECIFICATION file. It will generate a single artifact containing
-    the data for multiple locations (up to 15 locations only).
+    the data for multiple locations (up to 5 locations only).
 
     This script necessarily offloads work to the cluster, and so requires being
     run in the cluster environment.  It will qsub jobs for building artifacts
@@ -88,8 +88,8 @@ def multi_build_artifact(model_specification, locations, project, output_root, a
     The new cluster will kill jobs that go over memory without giving a useful message.
     """
 
-    if len(set(locations)) > 15:
-        raise ValueError(f'We can make an artifact for up to 15 locations. '
+    if len(set(locations)) > 5:
+        raise ValueError(f'We can make an artifact for up to 5 locations. '
                          f'You provided {len(set(locations))} locations.')
 
     if len(set(locations)) < 1:

--- a/src/vivarium_inputs/data_artifact/cli.py
+++ b/src/vivarium_inputs/data_artifact/cli.py
@@ -140,8 +140,8 @@ def multi_build_artifact(model_specification, locations, project, output_root, a
         f'--config_path {config_path} --verbose {verbose}'
     aggregate_job_name = f"{config_path.stem}_aggregate_artifacts"
     aggregate_command = build_submit_command(python_context_path, aggregate_job_name, 
-                                             project, error_log_dir, f'{aggregate_script} {aggregate_args}', memory,
-                                             archive=True, queue='all.q', hold=True, jids=jids)
+                                             project, error_log_dir, f'{aggregate_script} {aggregate_args}', memory=35,
+                                             archive=True, queue='all.q', hold=True, jids=jids, slots=20)
     submit_job(aggregate_command, aggregate_job_name)
 
 

--- a/src/vivarium_inputs/data_artifact/utilities.py
+++ b/src/vivarium_inputs/data_artifact/utilities.py
@@ -1,6 +1,71 @@
+import getpass
+import logging
+import pathlib
 import pkg_resources
 
 
 def get_versions():
     libraries = ['vivarium', 'vivarium_inputs', 'vivarium_public_health', 'gbd_mapping']
     return {k: pkg_resources.get_distribution(k).version for k in libraries}
+
+
+def get_output_base(output_root_arg: str) -> pathlib.Path:
+    """Resolve the correct output directory
+
+    Defaults to /ihme/scratch/users/{user}/vivarium_artifacts/
+    if no user passed output directory. Makes output directory
+    if doesn't already exist.
+
+    Parameters
+    ----------
+    output_root_arg
+        The output_root argument passed to the click executable
+
+    Returns
+    -------
+        A PathLike object containing the path to the output directory
+    """
+
+    if output_root_arg:
+        output_base = pathlib.Path(output_root_arg).resolve()
+    else:
+        output_base = (pathlib.Path('/share') / 'scratch' / 'users' /
+                       getpass.getuser() / 'vivarium_artifacts')
+
+    if not output_base.is_dir():
+        output_base.mkdir(parents=True)
+
+    return output_base
+
+
+def make_log_dir(output_root):
+    output_log_dir = get_output_base(output_root) / 'logs'
+
+    if not output_log_dir.is_dir():
+        output_log_dir.mkdir()
+
+    return output_log_dir
+
+
+def setup_logging(output_root, verbose, tag, model_specification, append):
+    """ Setup logging to write to a file in the output directory
+
+    Log file named as {model_specification}_{location}_build_artifact.log
+    to match naming format of qsubbed jobs. File saved in output directory
+    (either passed by user or default)/logs. Raises error if that output
+    directory is not found.
+
+    """
+
+    output_log_dir = make_log_dir(output_root)
+
+    log_level = logging.DEBUG if verbose else logging.ERROR
+    log_tag = f'_{tag}' if tag is not None else ''
+    spec_name = pathlib.Path(model_specification).resolve().stem
+    log_name = f'{output_log_dir}/{spec_name}{log_tag}_build_artifact.log'
+
+    logging.basicConfig(level=log_level,
+                        format='%(asctime)s %(levelname)-8s %(message)s',
+                        datefmt="%m-%d-%y %H:%M",
+                        filename=log_name,
+                        filemode='a' if append else 'w')


### PR DESCRIPTION
3 changes in this PR:

1) We weren't using the default output root for multi-build artifact so the individual location artifacts were disappearing and the resulting aggregated artifact only had the metadata keys

2) Add logging to aggregation - this is where most of the diff is coming from. I pulled out several helper functions into utilities so I could use them in both cli.py and aggregation.py to set up logging. This also involved updating a few tests.

3) Bump memory requests for aggregation job. With 3 locations, I as at 33GB and I bumped the memory to 20 slots/35GB so any more than 2 or 3 locations are probably going to get killed on new cluster/run away with memory on old but until we rewrite vivarium inputs to use indices/update aggregation to append to an hdf instead of holding things in memory, we're going to have memory issues.