### PR TITLE
actually filter by measure in filtering rr to cause restrictions

### DIFF
--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -244,7 +244,7 @@ def filter_relative_risk_to_cause_restrictions(data: pd.DataFrame) -> pd.DataFra
     affected_entities = set(data.affected_entity)
     affected_measures = set(data.affected_measure)
     for cause, measure in product(affected_entities, affected_measures):
-        df = data[(data.affected_entity == cause) & (data.affected_measure)]
+        df = data[(data.affected_entity == cause) & (data.affected_measure == measure)]
         cause = causes_map[cause]
         if measure == 'excess_mortality':
             start, end = utilities.get_age_group_ids_by_restriction(cause, 'yll')


### PR DESCRIPTION
noticed this while I was reworking core for indices - I think this was potentially duplicating data because we were looping over every cause, measure pair but then only grabbing the data for that cause and not actually filtering to the affected measure