### PR TITLE
Feature/reset indices

### DIFF
--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -85,6 +85,9 @@ class ArtifactBuilder:
         if entity_key not in self.artifact:
             self.process(entity_key)
         data = self.artifact.load(entity_key)
+        # pop structure is a df but not multi-indexed because it has no columns beyond our indexing dimensions
+        if isinstance(data, pd.DataFrame) and isinstance(data.index, pd.MultiIndex):
+            data = data.reset_index()
         return filter_data(data, **__) if isinstance(data, pd.DataFrame) else data
 
     def end_processing(self, event) -> None:

--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -85,7 +85,8 @@ class ArtifactBuilder:
         if entity_key not in self.artifact:
             self.process(entity_key)
         data = self.artifact.load(entity_key)
-        # demog dimensions is a df but not multi-indexed because it has no columns beyond our indexing dimensions
+        # demog dimensions and age bins are a df but not multi-indexed because they have no columns beyond our
+        # indexing dimensions
         if isinstance(data, pd.DataFrame) and isinstance(data.index, pd.MultiIndex):
             data = data.reset_index()
         return filter_data(data, **__) if isinstance(data, pd.DataFrame) else data

--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -85,9 +85,7 @@ class ArtifactBuilder:
         if entity_key not in self.artifact:
             self.process(entity_key)
         data = self.artifact.load(entity_key)
-        # demog dimensions and age bins are a df but not multi-indexed because they have no columns beyond our
-        # indexing dimensions
-        if isinstance(data, pd.DataFrame) and isinstance(data.index, pd.MultiIndex):
+        if isinstance(data, pd.DataFrame):  # could be metadata dict
             data = data.reset_index()
         return filter_data(data, **__) if isinstance(data, pd.DataFrame) else data
 

--- a/src/vivarium_inputs/data_artifact/builder.py
+++ b/src/vivarium_inputs/data_artifact/builder.py
@@ -85,7 +85,7 @@ class ArtifactBuilder:
         if entity_key not in self.artifact:
             self.process(entity_key)
         data = self.artifact.load(entity_key)
-        # pop structure is a df but not multi-indexed because it has no columns beyond our indexing dimensions
+        # demog dimensions is a df but not multi-indexed because it has no columns beyond our indexing dimensions
         if isinstance(data, pd.DataFrame) and isinstance(data.index, pd.MultiIndex):
             data = data.reset_index()
         return filter_data(data, **__) if isinstance(data, pd.DataFrame) else data

--- a/src/vivarium_inputs/data_artifact/passthrough.py
+++ b/src/vivarium_inputs/data_artifact/passthrough.py
@@ -23,7 +23,8 @@ class ArtifactPassthrough:
         data = loader(entity_key, self.location, self.modeled_causes)
 
         if isinstance(data, pd.DataFrame):
-            # demog dimensions is a df but not multi-indexed because it has no columns beyond our indexing dimensions
+            # demog dimensions and age bins are a df but not multi-indexed because they have no columns beyond our
+            # indexing dimensions
             if isinstance(data.index, pd.MultiIndex):
                 data = data.reset_index()
             for key, val in self.base_filter.items():

--- a/src/vivarium_inputs/data_artifact/passthrough.py
+++ b/src/vivarium_inputs/data_artifact/passthrough.py
@@ -23,6 +23,9 @@ class ArtifactPassthrough:
         data = loader(entity_key, self.location, self.modeled_causes)
 
         if isinstance(data, pd.DataFrame):
+            # pop structure is a df but not multi-indexed because it has no columns beyond our indexing dimensions
+            if isinstance(data.index, pd.MultiIndex):
+                data = data.reset_index()
             for key, val in self.base_filter.items():
                 if key in data.columns:
                     column_filters[key] = val

--- a/src/vivarium_inputs/data_artifact/passthrough.py
+++ b/src/vivarium_inputs/data_artifact/passthrough.py
@@ -22,11 +22,8 @@ class ArtifactPassthrough:
         entity_key = EntityKey(entity_key)
         data = loader(entity_key, self.location, self.modeled_causes)
 
-        if isinstance(data, pd.DataFrame):
-            # demog dimensions and age bins are a df but not multi-indexed because they have no columns beyond our
-            # indexing dimensions
-            if isinstance(data.index, pd.MultiIndex):
-                data = data.reset_index()
+        if isinstance(data, pd.DataFrame):  # could be a metadata dict
+            data = data.reset_index()
             for key, val in self.base_filter.items():
                 if key in data.columns:
                     column_filters[key] = val

--- a/src/vivarium_inputs/data_artifact/passthrough.py
+++ b/src/vivarium_inputs/data_artifact/passthrough.py
@@ -23,7 +23,7 @@ class ArtifactPassthrough:
         data = loader(entity_key, self.location, self.modeled_causes)
 
         if isinstance(data, pd.DataFrame):
-            # pop structure is a df but not multi-indexed because it has no columns beyond our indexing dimensions
+            # demog dimensions is a df but not multi-indexed because it has no columns beyond our indexing dimensions
             if isinstance(data.index, pd.MultiIndex):
                 data = data.reset_index()
             for key, val in self.base_filter.items():


### PR DESCRIPTION
This reset indices just before data are passed on to the simulation from load().

I have to check for dataframe because some data are dictionaries, and I have to check multindex because one dataframe does not have an index set -- demog dimensions.

This requires an accompanying change to vph to fix the function that writes to the artifact.

I tested this by building artifacts for all the smoke tests (Builder) and inspecting their keys, and running them with simulate (Passthrough)

EDIT: We no longer check for multindex because everything comes back with an index set -- see VPH. Tested again by building artifacts for integration yamls and running smoke tests with simulate