### PR TITLE
Feature/only set indices in reshape

### DIFF
--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -121,6 +121,7 @@ def get_birth_prevalence(entity: Union[Cause, Sequela], location_id: int) -> pd.
 def get_disability_weight(entity: Union[Cause, Sequela], location_id: int) -> pd.DataFrame:
     if entity.kind == 'cause':
         data = utility_data.get_demographic_dimensions(location_id, draws=True, value=0.0)
+        data = data.set_index(list(data.columns.difference({'value'})))
         if entity.sequelae:
             for sequela in entity.sequelae:
                 try:

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -354,7 +354,9 @@ def get_population_attributable_fraction(entity: Union[RiskFactor, Etiology], lo
     data = utilities.convert_affected_entity(data, 'cause_id')
     data.loc[data['measure_id'] == MEASURES['YLLs'], 'affected_measure'] = 'excess_mortality'
     data.loc[data['measure_id'] == MEASURES['YLDs'], 'affected_measure'] = 'incidence_rate'
-    data = data.groupby(['affected_entity', 'affected_measure']).apply(utilities.normalize, fill_value=0).reset_index()
+    data = (data.groupby(['affected_entity', 'affected_measure'])
+            .apply(utilities.normalize, fill_value=0)
+            .reset_index(drop=True))
     data = data.filter(DEMOGRAPHIC_COLUMNS + ['affected_entity', 'affected_measure'] + DRAW_COLUMNS)
     return data
 

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -67,7 +67,7 @@ def get_data(entity, measure: str, location: Union[str, int]):
         value_cols, var_name = DISTRIBUTION_COLUMNS, 'parameter'
     else:
         value_cols, var_name = DRAW_COLUMNS, 'draw'
-
+    import pdb; pdb.set_trace()
     data = utilities.reshape(data, value_cols=value_cols, var_name=var_name)
 
     return data
@@ -129,7 +129,7 @@ def get_disability_weight(entity: Union[Cause, Sequela], location_id: int) -> pd
                     # sequela prevalence does not exist so no point continuing with this sequela
                     continue
                 disability = get_data(sequela, 'disability_weight', location_id)
-                disability['location_id'] = location_id
+                disability.index = disability.index.set_levels([location_id], 'location_id')
                 data += prevalence * disability
     else:  # entity.kind == 'sequela'
         if not entity.healthstate.disability_weight_exists:

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -121,7 +121,7 @@ def get_birth_prevalence(entity: Union[Cause, Sequela], location_id: int) -> pd.
 def get_disability_weight(entity: Union[Cause, Sequela], location_id: int) -> pd.DataFrame:
     if entity.kind == 'cause':
         data = utility_data.get_demographic_dimensions(location_id, draws=True, value=0.0)
-        data = data.set_index(list(data.columns.difference({'value'})))
+        data = data.set_index(utilities.get_ordered_index_cols(data.columns.difference({'value'})))
         if entity.sequelae:
             for sequela in entity.sequelae:
                 try:

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -157,11 +157,10 @@ def get_remission(entity: Cause, location_id: int) -> pd.DataFrame:
 
 
 def get_cause_specific_mortality(entity: Cause, location_id: int) -> pd.DataFrame:
-    deaths = get_data(entity, 'deaths', location_id)
+    deaths = get_data(entity, 'deaths', location_id).reset_index(level='draw')  # population isn't by draws
     pop = get_data(Population(), 'structure', location_id)
-    data = deaths.merge(pop, on=DEMOGRAPHIC_COLUMNS)
-    data['value'] = data['value_x'] / data['value_y']
-    return data.drop(['value_x', 'value_y'], 'columns')
+    deaths /= pop
+    return deaths
 
 
 def get_excess_mortality(entity: Cause, location_id: int) -> pd.DataFrame:

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -67,7 +67,7 @@ def get_data(entity, measure: str, location: Union[str, int]):
         value_cols, var_name = DISTRIBUTION_COLUMNS, 'parameter'
     else:
         value_cols, var_name = DRAW_COLUMNS, 'draw'
-    import pdb; pdb.set_trace()
+
     data = utilities.reshape(data, value_cols=value_cols, var_name=var_name)
 
     return data
@@ -353,7 +353,7 @@ def get_population_attributable_fraction(entity: Union[RiskFactor, Etiology], lo
     data = utilities.convert_affected_entity(data, 'cause_id')
     data.loc[data['measure_id'] == MEASURES['YLLs'], 'affected_measure'] = 'excess_mortality'
     data.loc[data['measure_id'] == MEASURES['YLDs'], 'affected_measure'] = 'incidence_rate'
-    data = data.groupby(['affected_entity', 'affected_measure']).apply(utilities.normalize, fill_value=0)
+    data = data.groupby(['affected_entity', 'affected_measure']).apply(utilities.normalize, fill_value=0).reset_index()
     data = data.filter(DEMOGRAPHIC_COLUMNS + ['affected_entity', 'affected_measure'] + DRAW_COLUMNS)
     return data
 

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -121,7 +121,7 @@ def get_birth_prevalence(entity: Union[Cause, Sequela], location_id: int) -> pd.
 def get_disability_weight(entity: Union[Cause, Sequela], location_id: int) -> pd.DataFrame:
     if entity.kind == 'cause':
         data = utility_data.get_demographic_dimensions(location_id, draws=True, value=0.0)
-        data = data.set_index(utilities.get_ordered_index_cols(data.columns.difference({'value'})))
+        data = data.set_index(data.columns.difference({'value'}))
         if entity.sequelae:
             for sequela in entity.sequelae:
                 try:

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -91,11 +91,11 @@ def get_raw_incidence(entity: Union[Cause, Sequela], location_id: int) -> pd.Dat
 
 
 def get_incidence(entity: Union[Cause, Sequela], location_id: int) -> pd.DataFrame:
-    data = get_data(entity, 'raw_incidence', location_id).set_index(DEMOGRAPHIC_COLUMNS + ['draw'])
-    prevalence = get_data(entity, 'prevalence', location_id).set_index(DEMOGRAPHIC_COLUMNS + ['draw'])
+    data = get_data(entity, 'raw_incidence', location_id)
+    prevalence = get_data(entity, 'prevalence', location_id)
     # Convert from "True incidence" to the incidence rate among susceptibles
     data /= 1 - prevalence
-    return data.fillna(0).reset_index()
+    return data.fillna(0)
 
 
 def get_prevalence(entity: Union[Cause, Sequela], location_id: int) -> pd.DataFrame:
@@ -122,20 +122,17 @@ def get_birth_prevalence(entity: Union[Cause, Sequela], location_id: int) -> pd.
 
 def get_disability_weight(entity: Union[Cause, Sequela], location_id: int) -> pd.DataFrame:
     if entity.kind == 'cause':
-        data = (utility_data.get_demographic_dimensions(location_id, draws=True, value=0.0)
-                .set_index(DEMOGRAPHIC_COLUMNS + ['draw']))
+        data = utility_data.get_demographic_dimensions(location_id, draws=True, value=0.0)
         if entity.sequelae:
             for sequela in entity.sequelae:
                 try:
-                    prevalence = get_data(sequela, 'prevalence', location_id).set_index(DEMOGRAPHIC_COLUMNS + ['draw'])
+                    prevalence = get_data(sequela, 'prevalence', location_id)
                 except DataDoesNotExistError:
                     # sequela prevalence does not exist so no point continuing with this sequela
                     continue
                 disability = get_data(sequela, 'disability_weight', location_id)
                 disability['location_id'] = location_id
-                disability = disability.set_index(DEMOGRAPHIC_COLUMNS + ['draw'])
                 data += prevalence * disability
-        data = data.reset_index()
     else:  # entity.kind == 'sequela'
         if not entity.healthstate.disability_weight_exists:
             data = utility_data.get_demographic_dimensions(location_id, draws=True, value=0.0)
@@ -169,11 +166,11 @@ def get_cause_specific_mortality(entity: Cause, location_id: int) -> pd.DataFram
 
 
 def get_excess_mortality(entity: Cause, location_id: int) -> pd.DataFrame:
-    csmr = get_data(entity, 'cause_specific_mortality', location_id).set_index(DEMOGRAPHIC_COLUMNS + ['draw'])
-    prevalence = get_data(entity, 'prevalence', location_id).set_index(DEMOGRAPHIC_COLUMNS + ['draw'])
+    csmr = get_data(entity, 'cause_specific_mortality', location_id)
+    prevalence = get_data(entity, 'prevalence', location_id)
     data = (csmr / prevalence).fillna(0)
     data = data.replace([np.inf, -np.inf], 0)
-    return data.reset_index()
+    return data
 
 
 def get_case_fatality(entity: Cause, location_id: int):

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -121,7 +121,7 @@ def get_birth_prevalence(entity: Union[Cause, Sequela], location_id: int) -> pd.
 def get_disability_weight(entity: Union[Cause, Sequela], location_id: int) -> pd.DataFrame:
     if entity.kind == 'cause':
         data = utility_data.get_demographic_dimensions(location_id, draws=True, value=0.0)
-        data = data.set_index(list(data.columns.difference({'value'})))
+        data = data.set_index(utilities.get_ordered_index_cols(list(data.columns.difference({'value'}))))
         if entity.sequelae:
             for sequela in entity.sequelae:
                 try:

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -70,8 +70,6 @@ def get_data(entity, measure: str, location: Union[str, int]):
 
     data = utilities.reshape(data, value_cols=value_cols, var_name=var_name)
 
-    if isinstance(data.index, pd.MultiIndex):
-        data = data.reset_index()
     return data
 
 

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -292,7 +292,9 @@ def get_relative_risk(entity: Union[RiskFactor, CoverageGap], location_id: int) 
     result = []
     for affected_entity in data.affected_entity.unique():
         df = data[data.affected_entity == affected_entity]
-        df = df.groupby('parameter').apply(lambda d: utilities.normalize(d, fill_value=1))
+        df = (df.groupby('parameter')
+              .apply(utilities.normalize, fill_value=1)
+              .reset_index(drop=True))
         result.append(df)
     data = pd.concat(result)
     data = data.filter(DEMOGRAPHIC_COLUMNS + ['affected_entity', 'affected_measure', 'parameter'] + DRAW_COLUMNS)

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -159,8 +159,9 @@ def get_remission(entity: Cause, location_id: int) -> pd.DataFrame:
 def get_cause_specific_mortality(entity: Cause, location_id: int) -> pd.DataFrame:
     deaths = get_data(entity, 'deaths', location_id).reset_index(level='draw')  # population isn't by draws
     pop = get_data(Population(), 'structure', location_id)
-    deaths /= pop
-    return deaths
+    data = deaths.join(pop, lsuffix='_deaths', rsuffix='_pop')
+    data['value'] = data['value_deaths'].divide(data['value_pop'])
+    return data.drop(['value_deaths', 'value_pop'], 'columns')
 
 
 def get_excess_mortality(entity: Cause, location_id: int) -> pd.DataFrame:

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -121,7 +121,7 @@ def get_birth_prevalence(entity: Union[Cause, Sequela], location_id: int) -> pd.
 def get_disability_weight(entity: Union[Cause, Sequela], location_id: int) -> pd.DataFrame:
     if entity.kind == 'cause':
         data = utility_data.get_demographic_dimensions(location_id, draws=True, value=0.0)
-        data = data.set_index(data.columns.difference({'value'}))
+        data = data.set_index(list(data.columns.difference({'value'})))
         if entity.sequelae:
             for sequela in entity.sequelae:
                 try:

--- a/src/vivarium_inputs/interface.py
+++ b/src/vivarium_inputs/interface.py
@@ -62,6 +62,7 @@ def get_measure(entity: ModelableEntity, measure: str, location: str) -> pd.Data
 
     """
     data = core.get_data(entity, measure, location)
+    data = data.reset_index()
     data = utilities.scrub_gbd_conventions(data, location)
     validation.validate_for_simulation(data, entity, measure, location)
     return utilities.sort_data(data)
@@ -86,6 +87,7 @@ def get_population_structure(location: str) -> pd.DataFrame:
     """
     pop = Population()
     data = core.get_data(pop, 'structure', location)
+    data = data.reset_index()
     data = utilities.scrub_gbd_conventions(data, location)
     validation.validate_for_simulation(data, pop, 'structure', location)
     return utilities.sort_data(data)
@@ -104,6 +106,7 @@ def get_theoretical_minimum_risk_life_expectancy() -> pd.DataFrame:
     """
     pop = Population()
     data = core.get_data(pop, 'theoretical_minimum_risk_life_expectancy', 'Global')
+    data = data.reset_index()
     validation.validate_for_simulation(data, pop, 'theoretical_minimum_risk_life_expectancy', 'Global')
     return utilities.sort_data(data)
 
@@ -120,6 +123,7 @@ def get_age_bins() -> pd.DataFrame:
     """
     pop = Population()
     data = core.get_data(pop, 'age_bins', 'Global')
+    data = data.reset_index()
     validation.validate_for_simulation(data, pop, 'age_bins', 'Global')
     return utilities.sort_data(data)
 
@@ -141,6 +145,7 @@ def get_demographic_dimensions(location: str) -> pd.DataFrame:
     """
     pop = Population()
     data = core.get_data(pop, 'demographic_dimensions', location)
+    data = data.reset_index()
     data = utilities.scrub_gbd_conventions(data, location)
     validation.validate_for_simulation(data, pop, 'demographic_dimensions', location)
     return utilities.sort_data(data)

--- a/src/vivarium_inputs/utilities.py
+++ b/src/vivarium_inputs/utilities.py
@@ -177,6 +177,7 @@ def reshape(data: pd.DataFrame, value_cols: List = DRAW_COLUMNS, var_name: str =
             data.columns.name = var_name
             data = data.stack()
             data.name = 'value'
+            data = data.to_frame()  # stack turns df into a series
         else:  # already in right shape so set index
             data = data.set_index(get_ordered_index_cols(list(data.columns.difference({'value'}))))
     else:  # we've already set an index

--- a/src/vivarium_inputs/utilities.py
+++ b/src/vivarium_inputs/utilities.py
@@ -9,6 +9,7 @@ import pandas as pd
 from vivarium_inputs import utility_data
 from vivarium_inputs.globals import DRAW_COLUMNS, DEMOGRAPHIC_COLUMNS, SEXES, SPECIAL_AGES
 
+INDEX_COLUMNS = DEMOGRAPHIC_COLUMNS + ['draw', 'affected_entity', 'affected_measure', 'parameter']
 
 ##################################################
 # Functions to remove GBD conventions from data. #
@@ -163,17 +164,21 @@ def normalize_age(data: pd.DataFrame, fill_value: Real, cols_to_fill: List[str])
     return data
 
 
+def get_ordered_index_cols(data_columns: List):
+    return [i for i in INDEX_COLUMNS if i in data_columns] + list(set(data_columns).difference(INDEX_COLUMNS))
+
+
 def reshape(data: pd.DataFrame, value_cols: List = DRAW_COLUMNS, var_name: str = 'draw') -> pd.DataFrame:
     if isinstance(data, pd.DataFrame) and not isinstance(data.index, pd.MultiIndex):
         if set(data.columns).intersection(value_cols):  # reshape wide to long over value_cols
-            data = data.set_index(list(data.columns.difference(value_cols)))
+            data = data.set_index(get_ordered_index_cols(list(data.columns.difference(value_cols))))
             if value_cols == DRAW_COLUMNS:
                 data = data.rename(columns={draw: i for i, draw in enumerate(DRAW_COLUMNS)})
             data.columns.name = var_name
             data = data.stack()
             data.name = 'value'
         else:  # already in right shape so set index
-            data = data.set_index(list(data.columns.difference({'value'})))
+            data = data.set_index(get_ordered_index_cols(list(data.columns.difference({'value'}))))
     else:  # we've already set an index
         pass
     return data

--- a/src/vivarium_inputs/utilities.py
+++ b/src/vivarium_inputs/utilities.py
@@ -176,7 +176,7 @@ def reshape(data: pd.DataFrame, value_cols: List = DRAW_COLUMNS, var_name: str =
         else:  # already in right shape so set index
             data = data.set_index(list(data.columns.difference({'value'})))
     elif not data.columns.difference({'value'}).empty:  # we missed some columns that need to be in index
-        data.index = data.index.append(list(data.columns.difference({'value'})))
+        data = data.set_index(list(data.columns.difference({'value'})), append=True)
     else:  # we've already set the full index
         pass
     return data

--- a/src/vivarium_inputs/utilities.py
+++ b/src/vivarium_inputs/utilities.py
@@ -9,6 +9,7 @@ import pandas as pd
 from vivarium_inputs import utility_data
 from vivarium_inputs.globals import DRAW_COLUMNS, DEMOGRAPHIC_COLUMNS, SEXES, SPECIAL_AGES
 
+INDEX_COLUMNS = DEMOGRAPHIC_COLUMNS + ['draw', 'affected_entity', 'affected_measure', 'parameter']
 
 ##################################################
 # Functions to remove GBD conventions from data. #
@@ -163,10 +164,14 @@ def normalize_age(data: pd.DataFrame, fill_value: Real, cols_to_fill: List[str])
     return data
 
 
+def get_ordered_index_cols(data_columns: List):
+    return [i for i in INDEX_COLUMNS if i in data_columns] + list(set(data_columns).difference(INDEX_COLUMNS))
+
+
 def reshape(data: pd.DataFrame, value_cols: List = DRAW_COLUMNS, var_name: str = 'draw') -> pd.DataFrame:
     if isinstance(data, pd.DataFrame) and not isinstance(data.index, pd.MultiIndex):
         if set(data.columns).intersection(value_cols):  # reshape wide to long over value_cols
-            data = data.set_index(list(data.columns.difference(value_cols)))
+            data = data.set_index(get_ordered_index_cols(list(data.columns.difference(value_cols))))
             if value_cols == DRAW_COLUMNS:
                 data = data.rename(columns={draw: i for i, draw in enumerate(DRAW_COLUMNS)})
             data.columns.name = var_name
@@ -174,9 +179,10 @@ def reshape(data: pd.DataFrame, value_cols: List = DRAW_COLUMNS, var_name: str =
             data.name = 'value'
             data = data.to_frame()  # stack turns df into a series
         else:  # already in right shape so set index
-            data = data.set_index(list(data.columns.difference({'value'})))
+            data = data.set_index(get_ordered_index_cols(data.columns.difference({'value'})))
     elif not data.columns.difference({'value'}).empty:  # we missed some columns that need to be in index
         data = data.set_index(list(data.columns.difference({'value'})), append=True)
+        data = data.reorder_levels(get_ordered_index_cols(data.index.names))
     else:  # we've already set the full index
         pass
     return data

--- a/src/vivarium_inputs/utilities.py
+++ b/src/vivarium_inputs/utilities.py
@@ -175,6 +175,8 @@ def reshape(data: pd.DataFrame, value_cols: List = DRAW_COLUMNS, var_name: str =
             data = data.to_frame()  # stack turns df into a series
         else:  # already in right shape so set index
             data = data.set_index(list(data.columns.difference({'value'})))
+    elif data.columns.difference({'value'}):
+        data.index = data.index.append(list(data.columns.difference({'value'})))
     else:  # we've already set an index
         pass
     return data

--- a/src/vivarium_inputs/utilities.py
+++ b/src/vivarium_inputs/utilities.py
@@ -9,7 +9,6 @@ import pandas as pd
 from vivarium_inputs import utility_data
 from vivarium_inputs.globals import DRAW_COLUMNS, DEMOGRAPHIC_COLUMNS, SEXES, SPECIAL_AGES
 
-INDEX_COLUMNS = DEMOGRAPHIC_COLUMNS + ['draw', 'affected_entity', 'affected_measure', 'parameter']
 
 ##################################################
 # Functions to remove GBD conventions from data. #
@@ -164,14 +163,10 @@ def normalize_age(data: pd.DataFrame, fill_value: Real, cols_to_fill: List[str])
     return data
 
 
-def get_ordered_index_cols(data_columns: List):
-    return [i for i in INDEX_COLUMNS if i in data_columns] + list(set(data_columns).difference(INDEX_COLUMNS))
-
-
 def reshape(data: pd.DataFrame, value_cols: List = DRAW_COLUMNS, var_name: str = 'draw') -> pd.DataFrame:
     if isinstance(data, pd.DataFrame) and not isinstance(data.index, pd.MultiIndex):
         if set(data.columns).intersection(value_cols):  # reshape wide to long over value_cols
-            data = data.set_index(get_ordered_index_cols(list(data.columns.difference(value_cols))))
+            data = data.set_index(list(data.columns.difference(value_cols)))
             if value_cols == DRAW_COLUMNS:
                 data = data.rename(columns={draw: i for i, draw in enumerate(DRAW_COLUMNS)})
             data.columns.name = var_name
@@ -179,7 +174,7 @@ def reshape(data: pd.DataFrame, value_cols: List = DRAW_COLUMNS, var_name: str =
             data.name = 'value'
             data = data.to_frame()  # stack turns df into a series
         else:  # already in right shape so set index
-            data = data.set_index(get_ordered_index_cols(list(data.columns.difference({'value'}))))
+            data = data.set_index(list(data.columns.difference({'value'})))
     else:  # we've already set an index
         pass
     return data

--- a/src/vivarium_inputs/utilities.py
+++ b/src/vivarium_inputs/utilities.py
@@ -175,7 +175,7 @@ def reshape(data: pd.DataFrame, value_cols: List = DRAW_COLUMNS, var_name: str =
             data = data.to_frame()  # stack turns df into a series
         else:  # already in right shape so set index
             data = data.set_index(list(data.columns.difference({'value'})))
-    elif data.columns.difference({'value'}):  # we missed some columns that need to be in index
+    elif not data.columns.difference({'value'}).empty:  # we missed some columns that need to be in index
         data.index = data.index.append(list(data.columns.difference({'value'})))
     else:  # we've already set the full index
         pass

--- a/src/vivarium_inputs/utilities.py
+++ b/src/vivarium_inputs/utilities.py
@@ -175,9 +175,9 @@ def reshape(data: pd.DataFrame, value_cols: List = DRAW_COLUMNS, var_name: str =
             data = data.to_frame()  # stack turns df into a series
         else:  # already in right shape so set index
             data = data.set_index(list(data.columns.difference({'value'})))
-    elif data.columns.difference({'value'}):
+    elif data.columns.difference({'value'}):  # we missed some columns that need to be in index
         data.index = data.index.append(list(data.columns.difference({'value'})))
-    else:  # we've already set an index
+    else:  # we've already set the full index
         pass
     return data
 


### PR DESCRIPTION
because I previously had the reset_indices call at the end of get_data, I missed dealing with all the cases of measure specific functions calling out to get_data and getting back data with indices. when I moved that reset_indices later for scrubbing gbd conventions, all of a sudden all of these issues popped up. 

this puts the reset_indices call in interface after the call to core.get_data and fixes all of measure specific functions that call out to get_data to handle indices. It also updates reshape to handle the case where data comes in with a partial multiindex and to not return series out of the stack call. It also enforces an order on the levels of the multiindex because I was getting some crazy errors in disability_weight when I was trying to add disability weight to prev*disability weight and I had different order of levels