### PR TITLE
add set order of levels to reshape + always return dataframe + handle…

### DIFF
--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -296,7 +296,9 @@ def get_relative_risk(entity: Union[RiskFactor, CoverageGap], location_id: int) 
     result = []
     for affected_entity in data.affected_entity.unique():
         df = data[data.affected_entity == affected_entity]
-        df = df.groupby('parameter').apply(lambda d: utilities.normalize(d, fill_value=1))
+        df = (df.groupby('parameter')
+              .apply(utilities.normalize, fill_value=1)
+              .reset_index(drop=True))
         result.append(df)
     data = pd.concat(result)
     data = data.filter(DEMOGRAPHIC_COLUMNS + ['affected_entity', 'affected_measure', 'parameter'] + DRAW_COLUMNS)
@@ -358,7 +360,9 @@ def get_population_attributable_fraction(entity: Union[RiskFactor, Etiology], lo
     data = utilities.convert_affected_entity(data, 'cause_id')
     data.loc[data['measure_id'] == MEASURES['YLLs'], 'affected_measure'] = 'excess_mortality'
     data.loc[data['measure_id'] == MEASURES['YLDs'], 'affected_measure'] = 'incidence_rate'
-    data = data.groupby(['affected_entity', 'affected_measure']).apply(utilities.normalize, fill_value=0)
+    data = (data.groupby(['affected_entity', 'affected_measure'])
+            .apply(utilities.normalize, fill_value=0)
+            .reset_index(drop=True))
     data = data.filter(DEMOGRAPHIC_COLUMNS + ['affected_entity', 'affected_measure'] + DRAW_COLUMNS)
     return data
 

--- a/src/vivarium_inputs/utilities.py
+++ b/src/vivarium_inputs/utilities.py
@@ -9,6 +9,7 @@ import pandas as pd
 from vivarium_inputs import utility_data
 from vivarium_inputs.globals import DRAW_COLUMNS, DEMOGRAPHIC_COLUMNS, SEXES, SPECIAL_AGES
 
+INDEX_COLUMNS = DEMOGRAPHIC_COLUMNS + ['draw', 'affected_entity', 'affected_measure', 'parameter']
 
 ##################################################
 # Functions to remove GBD conventions from data. #
@@ -163,18 +164,26 @@ def normalize_age(data: pd.DataFrame, fill_value: Real, cols_to_fill: List[str])
     return data
 
 
+def get_ordered_index_cols(data_columns: List):
+    return [i for i in INDEX_COLUMNS if i in data_columns] + list(set(data_columns).difference(INDEX_COLUMNS))
+
+
 def reshape(data: pd.DataFrame, value_cols: List = DRAW_COLUMNS, var_name: str = 'draw') -> pd.DataFrame:
     if isinstance(data, pd.DataFrame) and not isinstance(data.index, pd.MultiIndex):
         if set(data.columns).intersection(value_cols):  # reshape wide to long over value_cols
-            data = data.set_index(list(data.columns.difference(value_cols)))
+            data = data.set_index(get_ordered_index_cols(list(data.columns.difference(value_cols))))
             if value_cols == DRAW_COLUMNS:
                 data = data.rename(columns={draw: i for i, draw in enumerate(DRAW_COLUMNS)})
             data.columns.name = var_name
             data = data.stack()
             data.name = 'value'
+            data = data.to_frame()  # stack turns df into a series
         else:  # already in right shape so set index
-            data = data.set_index(list(data.columns.difference({'value'})))
-    else:  # we've already set an index
+            data = data.set_index(get_ordered_index_cols(data.columns.difference({'value'})))
+    elif not data.columns.difference({'value'}).empty:  # we missed some columns that need to be in index
+        data = data.set_index(list(data.columns.difference({'value'})), append=True)
+        data = data.reorder_levels(get_ordered_index_cols(data.index.names))
+    else:  # we've already set the full index
         pass
     return data
 

--- a/src/vivarium_inputs/utilities.py
+++ b/src/vivarium_inputs/utilities.py
@@ -164,14 +164,14 @@ def normalize_age(data: pd.DataFrame, fill_value: Real, cols_to_fill: List[str])
     return data
 
 
-def get_ordered_index_cols(data_columns: List):
-    return [i for i in INDEX_COLUMNS if i in data_columns] + list(set(data_columns).difference(INDEX_COLUMNS))
+def get_ordered_index_cols(data_columns: pd.Index):
+    return [i for i in INDEX_COLUMNS if i in data_columns] + list(data_columns.difference(INDEX_COLUMNS))
 
 
 def reshape(data: pd.DataFrame, value_cols: List = DRAW_COLUMNS, var_name: str = 'draw') -> pd.DataFrame:
     if isinstance(data, pd.DataFrame) and not isinstance(data.index, pd.MultiIndex):
         if set(data.columns).intersection(value_cols):  # reshape wide to long over value_cols
-            data = data.set_index(get_ordered_index_cols(list(data.columns.difference(value_cols))))
+            data = data.set_index(get_ordered_index_cols(data.columns.difference(value_cols)))
             if value_cols == DRAW_COLUMNS:
                 data = data.rename(columns={draw: i for i, draw in enumerate(DRAW_COLUMNS)})
             data.columns.name = var_name
@@ -181,7 +181,7 @@ def reshape(data: pd.DataFrame, value_cols: List = DRAW_COLUMNS, var_name: str =
         else:  # already in right shape so set index
             data = data.set_index(get_ordered_index_cols(data.columns.difference({'value'})))
     elif not data.columns.difference({'value'}).empty:  # we missed some columns that need to be in index
-        data = data.set_index(list(data.columns.difference({'value'})), append=True)
+        data = data.set_index(data.columns.difference({'value'}), append=True)
         data = data.reorder_levels(get_ordered_index_cols(data.index.names))
     else:  # we've already set the full index
         pass


### PR DESCRIPTION
updates to reshape: 
1. add set order of levels (will be important for when we start multiplying/adding/dividing multiple dfs in core)
2. always return a dataframe
3. handle the case where data comes in with partial index set (this is primarily to handle the case of cause_specific_mortality where I have to drop draws out of the index of deaths in order to combine with pop which doesn't have draws and I want to make sure it gets put back in via reshape)

There are also 2 small updates to core because we need to reset indices after groupbys or things go into reshape with a multiindex that contains columns that are also in the data 