### PR TITLE
Feature/lbwsg

### DIFF
--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -191,8 +191,8 @@ def get_exposure(entity: Union[RiskFactor, AlternativeRiskFactor, CoverageGap], 
     data = extract.extract_data(entity, 'exposure', location_id)
     data = data.drop('modelable_entity_id', 'columns')
 
-    if entity in EXTRA_RESIDUAL_CATEGORY:
-        data = data[data.parameter != EXTRA_RESIDUAL_CATEGORY[entity]]
+    if entity.name in EXTRA_RESIDUAL_CATEGORY:
+        data = data[data.parameter != EXTRA_RESIDUAL_CATEGORY[entity.name]]
 
     if entity.kind in ['risk_factor', 'alternative_risk_factor']:
         data = utilities.filter_data_by_restrictions(data, entity,

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from vivarium_inputs import utilities, extract, utility_data
 from vivarium_inputs.globals import (InvalidQueryError, DEMOGRAPHIC_COLUMNS, MEASURES, SEXES, DRAW_COLUMNS,
-                                     Population, DataDoesNotExistError)
+                                     Population, DataDoesNotExistError, EXTRA_RESIDUAL_CATEGORY)
 from vivarium_inputs.mapping_extension import AlternativeRiskFactor, HealthcareEntity, HealthTechnology
 
 
@@ -191,10 +191,8 @@ def get_exposure(entity: Union[RiskFactor, AlternativeRiskFactor, CoverageGap], 
     data = extract.extract_data(entity, 'exposure', location_id)
     data = data.drop('modelable_entity_id', 'columns')
 
-    if entity.name == 'low_birth_weight_and_short_gestation':
-        # residual cat is added by get_draws but all cats modeled for lbwsg so
-        # has to be removed
-        data = data[data.parameter != 'cat124']
+    if entity in EXTRA_RESIDUAL_CATEGORY:
+        data = data[data.parameter != EXTRA_RESIDUAL_CATEGORY[entity]]
 
     if entity.kind in ['risk_factor', 'alternative_risk_factor']:
         data = utilities.filter_data_by_restrictions(data, entity,

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -191,6 +191,11 @@ def get_exposure(entity: Union[RiskFactor, AlternativeRiskFactor, CoverageGap], 
     data = extract.extract_data(entity, 'exposure', location_id)
     data = data.drop('modelable_entity_id', 'columns')
 
+    if entity.name == 'low_birth_weight_and_short_gestation':
+        # residual cat is added by get_draws but all cats modeled for lbwsg so
+        # has to be removed
+        data = data[data.parameter != 'cat124']
+
     if entity.kind in ['risk_factor', 'alternative_risk_factor']:
         data = utilities.filter_data_by_restrictions(data, entity,
                                                      'outer', utility_data.get_age_group_ids())

--- a/src/vivarium_inputs/globals.py
+++ b/src/vivarium_inputs/globals.py
@@ -146,6 +146,13 @@ BOUNDARY_SPECIAL_CASES = {
 PROBLEMATIC_RISKS = {risk_factors.zinc_deficiency.name:
                          "zinc deficiency relative risk data breaks central comp interpolation."}
 
+# residual cat is added by get_draws but all cats modeled for lbwsg so
+# has to be removed
+EXTRA_RESIDUAL_CATEGORY = {risk_factors.low_birth_weight_and_short_gestation: 'cat124'}
+
+# LBWSG paf has data outside neonatal preterm birth age restrictions (but is all 1.0) - K.W. 4/2/19
+PAF_OUTSIDE_AGE_RESTRICTIONS = {risk_factors.low_birth_weight_and_short_gestation: [causes.neonatal_preterm_birth]}
+
 
 class Population(ModelableEntity):
     """Entity wrapper for querying population measures."""

--- a/src/vivarium_inputs/globals.py
+++ b/src/vivarium_inputs/globals.py
@@ -148,10 +148,10 @@ PROBLEMATIC_RISKS = {risk_factors.zinc_deficiency.name:
 
 # residual cat is added by get_draws but all cats modeled for lbwsg so
 # has to be removed
-EXTRA_RESIDUAL_CATEGORY = {risk_factors.low_birth_weight_and_short_gestation: 'cat124'}
+EXTRA_RESIDUAL_CATEGORY = {risk_factors.low_birth_weight_and_short_gestation.name: 'cat124'}
 
 # LBWSG paf has data outside neonatal preterm birth age restrictions (but is all 1.0) - K.W. 4/2/19
-PAF_OUTSIDE_AGE_RESTRICTIONS = {risk_factors.low_birth_weight_and_short_gestation: [causes.neonatal_preterm_birth]}
+PAF_OUTSIDE_AGE_RESTRICTIONS = {risk_factors.low_birth_weight_and_short_gestation.name: [causes.neonatal_preterm_birth]}
 
 
 class Population(ModelableEntity):

--- a/src/vivarium_inputs/validation/raw.py
+++ b/src/vivarium_inputs/validation/raw.py
@@ -1654,8 +1654,8 @@ def check_paf_rr_exposure_age_groups(paf: pd.DataFrame, context: RawValidationCo
         extra_paf = set(paf.age_group_id).intersection(valid_but_no_rr)
 
         measure = 'YLLs' if measure_id == MEASURES['YLLs'] else 'YLDs'
-        if not_valid_paf and not (entity in PAF_OUTSIDE_AGE_RESTRICTIONS
-                                  and cause in PAF_OUTSIDE_AGE_RESTRICTIONS[entity]):
+        if not_valid_paf and not (entity.name in PAF_OUTSIDE_AGE_RESTRICTIONS
+                                  and cause in PAF_OUTSIDE_AGE_RESTRICTIONS[entity.name]):
             raise DataAbnormalError(f'{measure} paf for {cause.name} and {entity.name} have data outside '
                                     f'of cause restrictions: {set(paf.age_group_id) - cause_restriction_ages}')
 

--- a/src/vivarium_inputs/validation/raw.py
+++ b/src/vivarium_inputs/validation/raw.py
@@ -1505,10 +1505,10 @@ def check_mort_morb_flags(data: pd.DataFrame, yld_only: bool, yll_only: bool) ->
                                                      'rows with only one of the mortality or morbidity flags set to 1.')
     else:
         if yld_only and mortality.any():
-            raise DataAbnormalError(base_error_msg + 'rows with the mortality flag set to 1 but the affected entity'
+            raise DataAbnormalError(base_error_msg + 'rows with the mortality flag set to 1 but the affected entity '
                                                      'is restricted to yld_only.')
         elif yll_only and morbidity.any():
-            raise DataAbnormalError(base_error_msg + 'rows with the morbidity flag set to 1 but the affected entity'
+            raise DataAbnormalError(base_error_msg + 'rows with the morbidity flag set to 1 but the affected entity '
                                                      'is restricted to yll_only.')
         else:
             pass

--- a/src/vivarium_inputs/validation/raw.py
+++ b/src/vivarium_inputs/validation/raw.py
@@ -1654,7 +1654,9 @@ def check_paf_rr_exposure_age_groups(paf: pd.DataFrame, context: RawValidationCo
         extra_paf = set(paf.age_group_id).intersection(valid_but_no_rr)
 
         measure = 'YLLs' if measure_id == MEASURES['YLLs'] else 'YLDs'
-        if not_valid_paf:
+        # FIXME: LBWSG paf has data outside neonatal preterm birth age restrictions (but is all 1.0) - K.W. 4/2/19
+        if not_valid_paf and not (entity.name == 'low_birth_weight_and_short_gestation'
+                                  and cause.name == 'neonatal_preterm_birth'):
             raise DataAbnormalError(f'{measure} paf for {cause.name} and {entity.name} have data outside '
                                     f'of cause restrictions: {set(paf.age_group_id) - cause_restriction_ages}')
 

--- a/src/vivarium_inputs/validation/raw.py
+++ b/src/vivarium_inputs/validation/raw.py
@@ -10,7 +10,7 @@ from gbd_mapping import (ModelableEntity, Cause, Sequela, RiskFactor, Etiology, 
 from vivarium_inputs import utility_data
 from vivarium_inputs.globals import (DRAW_COLUMNS, DEMOGRAPHIC_COLUMNS, SEXES, SPECIAL_AGES, METRICS, MEASURES,
                                      PROTECTIVE_CAUSE_RISK_PAIRS, DataAbnormalError, InvalidQueryError,
-                                     DataDoesNotExistError, Population, PROBLEMATIC_RISKS)
+                                     DataDoesNotExistError, Population, PROBLEMATIC_RISKS, PAF_OUTSIDE_AGE_RESTRICTIONS)
 
 from vivarium_inputs.mapping_extension import AlternativeRiskFactor, HealthcareEntity, HealthTechnology
 from vivarium_inputs.utilities import get_restriction_age_ids, get_restriction_age_boundary
@@ -1654,9 +1654,8 @@ def check_paf_rr_exposure_age_groups(paf: pd.DataFrame, context: RawValidationCo
         extra_paf = set(paf.age_group_id).intersection(valid_but_no_rr)
 
         measure = 'YLLs' if measure_id == MEASURES['YLLs'] else 'YLDs'
-        # FIXME: LBWSG paf has data outside neonatal preterm birth age restrictions (but is all 1.0) - K.W. 4/2/19
-        if not_valid_paf and not (entity.name == 'low_birth_weight_and_short_gestation'
-                                  and cause.name == 'neonatal_preterm_birth'):
+        if not_valid_paf and not (entity in PAF_OUTSIDE_AGE_RESTRICTIONS
+                                  and cause in PAF_OUTSIDE_AGE_RESTRICTIONS[entity]):
             raise DataAbnormalError(f'{measure} paf for {cause.name} and {entity.name} have data outside '
                                     f'of cause restrictions: {set(paf.age_group_id) - cause_restriction_ages}')
 

--- a/tests/validation/test_raw.py
+++ b/tests/validation/test_raw.py
@@ -35,8 +35,8 @@ def metrics_mock(mocker):
 @pytest.mark.parametrize('mort, morb, yld_only, yll_only, match',
                          [([0, 1, 1], [0, 1, 1], True, False, 'set to 0'),
                           ([1, 1, 0], [1, 1, 1], True, False, 'only one'),
-                          ([1, 1, 1], [0, 0, 0], False, False, 'not restricted to yll_only'),
-                          ([0, 0, 0], [1, 1, 1], False, False, 'not restricted to yld_only'),
+                          ([1, 1, 1], [0, 0, 0], True, False, 'restricted to yld_only'),
+                          ([0, 0, 0], [1, 1, 1], False, True, 'restricted to yll_only'),
                           ([1, 0, 0], [0, 1, 1], True, False, 'is restricted to yld_only'),
                           ([1, 0, 2], [0, 1, 1], False, False, 'outside the expected')])
 def test_check_mort_morb_flags_fail(mort, morb, yld_only, yll_only, match):


### PR DESCRIPTION
here's most of the fixes for lbwsg data including:

1. don't check age/sex ids/restrictions by category in the raw validator for exposure. this was causing problems for some countries where for a certain category, one sex would have all 0s and so trigger that the data was empty but the entity didn't have sex restrictions. I don't really think it makes sense to be checking these by category anyways - if any category has invalid sex/age ids, we'll still raise an error if we check all the data at once.

2. update the check mortality/morbidity flags function to only break if data violates a restriction, not if it doesn't meet one. This is because the RR data for lbwsg is always mortality = 1, morbidity = 0 but the affected causes aren't yll only.

3. the PAF data for lbwsg and neonatal preterm is all 1.0 but it includes age groups that are out of the age restrictions of neonatal preterm. this is an error in the data so I just special-cased it to skip this check in check_paf_rr_exposure_groups

The remaining fixes will be around trying to handle the size of the RR data and will probably have to do something with the indices (although I'm going to have to get clever with intervals it looks like). 