### PR TITLE
Bugfix/gbddummy error msg

### DIFF
--- a/src/vivarium_inputs/globals.py
+++ b/src/vivarium_inputs/globals.py
@@ -9,11 +9,12 @@ try:
     from gbd_artifacts.exceptions import NoBestVersionError
     from get_draws.api import EmptyDataFrameException, InputsException
 
-except ModuleNotFoundError:
+except ModuleNotFoundError as e:
     class GbdDummy:
         """Mock class to wrap internal dependency."""
         def __getattr__(self, item):
-            raise ModuleNotFoundError("Required package vivarium_gbd_access not found.")
+            raise ModuleNotFoundError("Required package vivarium_gbd_access could not be imported because "
+                                      f"{e}.")
     gbd = GbdDummy()
 
     class NoBestVersionError(Exception):

--- a/src/vivarium_inputs/globals.py
+++ b/src/vivarium_inputs/globals.py
@@ -6,15 +6,19 @@ from gbd_mapping import ModelableEntity, causes, risk_factors
 # IHME data and allow CI and automated testing to work.
 try:
     from vivarium_gbd_access import gbd
-    from gbd_artifacts.exceptions import NoBestVersionError
-    from get_draws.api import EmptyDataFrameException, InputsException
 
-except ModuleNotFoundError as e:
+    try:
+        from gbd_artifacts.exceptions import NoBestVersionError
+        from get_draws.api import EmptyDataFrameException, InputsException
+    except  ModuleNotFoundError:
+        raise RuntimeError("Problem importing gbd_artifacts.exceptions or get_draws.api.")
+
+except ModuleNotFoundError:
     class GbdDummy:
         """Mock class to wrap internal dependency."""
+
         def __getattr__(self, item):
-            raise ModuleNotFoundError("Required package vivarium_gbd_access could not be imported because "
-                                      f"{e}.")
+            raise ModuleNotFoundError("Required package vivarium_gbd_access not found.")
     gbd = GbdDummy()
 
     class NoBestVersionError(Exception):

--- a/src/vivarium_inputs/globals.py
+++ b/src/vivarium_inputs/globals.py
@@ -16,7 +16,6 @@ try:
 except ModuleNotFoundError:
     class GbdDummy:
         """Mock class to wrap internal dependency."""
-
         def __getattr__(self, item):
             raise ModuleNotFoundError("Required package vivarium_gbd_access not found.")
     gbd = GbdDummy()


### PR DESCRIPTION
This clarifies the error message in the case where vivarium_gbd_access is installed correctly but one of gbd_artifacts or get_draws is not.

if vivarium_gbd_access imports correctly, we need those exceptions for normal operation. If it doesn't, we are in a test situation and want to mock everything anyways.

I ran in to this case and the previous error message implicated vivarium_gbd_access which was not the case.