### PR TITLE
filter pop data when comparing to sex-restricted deaths data

### DIFF
--- a/src/vivarium_inputs/validation/raw.py
+++ b/src/vivarium_inputs/validation/raw.py
@@ -673,7 +673,8 @@ def validate_deaths(data: pd.DataFrame, entity: Cause, context: RawValidationCon
     population = context['population']
     population = population[(population.age_group_id.isin(data.age_group_id.unique()))
                             & (population.year_id.isin(data.year_id.unique()))
-                            & (population.sex_id != context['sexes']['Combined'])].set_index(idx_cols).population
+                            & (population.sex_id != context['sexes']['Combined'])
+                            & (population.sex_id.isin(data.sex_id.unique()))].set_index(idx_cols).population
     check_value_columns_boundary(data.set_index(idx_cols), population, 'upper',
                                  value_columns=DRAW_COLUMNS, inclusive=True, error=None)
 


### PR DESCRIPTION
we compare deaths to population as a sanity check in the raw validators and we were filtering the pop to just the ages in the deaths data but not the sexes. this adds that so that sex restricted causes (e.g., uterine cancer) don't error out with misalignment here