### PR TITLE
add core-maths to pkg deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ if __name__ == "__main__":
         'vivarium>=0.8.18',
         'vivarium_public_health>=0.9.0',
         'gbd_mapping>=2.0.0',
+        'core-maths'
     ]
 
     data_requires = [

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,11 @@ if __name__ == "__main__":
         'vivarium>=0.8.18',
         'vivarium_public_health>=0.9.0',
         'gbd_mapping>=2.0.0',
-        'core-maths'
     ]
 
     data_requires = [
         'vivarium-gbd-access>=2.0.0',
+        'core-maths'
     ]
 
     test_requirements = [


### PR DESCRIPTION
I was just bit by this. As far as I can tell this dep is just missing. A clean install of vivarium-inputs does not yield core-maths

