### PR TITLE
First gbd update checkin, remove CoverageGap and survey data referenc…

### DIFF
--- a/ci/travis-test.sh
+++ b/ci/travis-test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 source builds/venv/bin/activate
-pytest --ignore=./tests/extract tests/
+pytest tests/

--- a/ci/travis-test.sh
+++ b/ci/travis-test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 source builds/venv/bin/activate
-pytest tests/
+pytest --ignore=./tests/extract tests/

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -1,7 +1,7 @@
 from typing import Union
 from itertools import product
 
-from gbd_mapping import Cause, Sequela, RiskFactor, CoverageGap, Etiology, Covariate, causes
+from gbd_mapping import Cause, Sequela, RiskFactor, Etiology, Covariate, causes
 import pandas as pd
 import numpy as np
 from loguru import logger
@@ -186,7 +186,7 @@ def get_deaths(entity: Cause, location_id: int) -> pd.DataFrame:
     return data
 
 
-def get_exposure(entity: Union[RiskFactor, AlternativeRiskFactor, CoverageGap], location_id: int) -> pd.DataFrame:
+def get_exposure(entity: Union[RiskFactor, AlternativeRiskFactor], location_id: int) -> pd.DataFrame:
     data = extract.extract_data(entity, 'exposure', location_id)
     data = data.drop('modelable_entity_id', 'columns')
 
@@ -273,7 +273,7 @@ def filter_relative_risk_to_cause_restrictions(data: pd.DataFrame) -> pd.DataFra
     return data
 
 
-def get_relative_risk(entity: Union[RiskFactor, CoverageGap], location_id: int) -> pd.DataFrame:
+def get_relative_risk(entity: Union[RiskFactor], location_id: int) -> pd.DataFrame:
     data = extract.extract_data(entity, 'relative_risk', location_id)
 
     if entity.kind == 'risk_factor':

--- a/src/vivarium_inputs/data_artifact/loaders.py
+++ b/src/vivarium_inputs/data_artifact/loaders.py
@@ -1,6 +1,6 @@
 from typing import Set
 
-from gbd_mapping import causes, risk_factors, sequelae, covariates, etiologies, coverage_gaps
+from gbd_mapping import causes, risk_factors, sequelae, covariates, etiologies
 
 from vivarium_inputs.globals import InvalidQueryError
 from vivarium_inputs.interface import (get_measure, get_population_structure, get_age_bins,

--- a/src/vivarium_inputs/mapping_extension/alternative_risk_factor.py
+++ b/src/vivarium_inputs/mapping_extension/alternative_risk_factor.py
@@ -1,5 +1,5 @@
 from gbd_mapping.base_template import Restrictions
-from gbd_mapping.id import reiid
+from gbd_mapping.id import rei_id
 from gbd_mapping import causes
 
 from .alternative_risk_factor_template import AlternativeRiskFactors, AlternativeRiskFactor
@@ -8,20 +8,11 @@ alternative_risk_factors = AlternativeRiskFactors(
     child_underweight=AlternativeRiskFactor(
         name='child_underweight',
         kind='alternative_risk_factor',
-        gbd_id=reiid(94),
+        gbd_id=rei_id(94),
         level=4,
         most_detailed=True,
         distribution='ensemble',
         population_attributable_fraction_calculation_type='categorical',
-        exposure_exists=True,
-        exposure_standard_deviation_exists=True,
-        exposure_year_type='binned',
-        relative_risk_exists=True,
-        relative_risk_in_range=False,
-        population_attributable_fraction_yll_exists=True,
-        population_attributable_fraction_yll_in_range=True,
-        population_attributable_fraction_yld_exists=True,
-        population_attributable_fraction_yld_in_range=True,
         restrictions=Restrictions(
             male_only=False,
             female_only=False,
@@ -31,8 +22,6 @@ alternative_risk_factors = AlternativeRiskFactors(
             yll_age_group_id_end=235,
             yld_age_group_id_start=2,
             yld_age_group_id_end=235,
-            violated=('exposure_age_restriction_violated', 'relative_risk_age_restriction_violated',
-                      'population_attributable_fraction_yll_age_restriction_violated', )
         ),
         affected_causes=(causes.all_causes, causes.communicable_maternal_neonatal_and_nutritional_diseases,
                          causes.diarrheal_diseases, causes.lower_respiratory_infections, causes.measles,
@@ -48,20 +37,11 @@ alternative_risk_factors = AlternativeRiskFactors(
     child_wasting=AlternativeRiskFactor(
         name='child_wasting',
         kind='alternative_risk_factor',
-        gbd_id=reiid(240),
+        gbd_id=rei_id(240),
         level=4,
         most_detailed=True,
         distribution='ensemble',
         population_attributable_fraction_calculation_type='categorical',
-        exposure_exists=True,
-        exposure_standard_deviation_exists=True,
-        exposure_year_type='binned',
-        relative_risk_exists=True,
-        relative_risk_in_range=False,
-        population_attributable_fraction_yll_exists=True,
-        population_attributable_fraction_yll_in_range=True,
-        population_attributable_fraction_yld_exists=True,
-        population_attributable_fraction_yld_in_range=True,
         restrictions=Restrictions(
             male_only=False,
             female_only=False,
@@ -71,8 +51,6 @@ alternative_risk_factors = AlternativeRiskFactors(
             yll_age_group_id_end=235,
             yld_age_group_id_start=2,
             yld_age_group_id_end=235,
-            violated=('exposure_age_restriction_violated', 'relative_risk_age_restriction_violated',
-                      'population_attributable_fraction_yll_age_restriction_violated', )
         ),
         affected_causes=(causes.all_causes, causes.communicable_maternal_neonatal_and_nutritional_diseases,
                          causes.diarrheal_diseases, causes.lower_respiratory_infections, causes.measles,
@@ -88,20 +66,11 @@ alternative_risk_factors = AlternativeRiskFactors(
     child_stunting=AlternativeRiskFactor(
         name='child_stunting',
         kind='alternative_risk_factor',
-        gbd_id=reiid(241),
+        gbd_id=rei_id(241),
         level=4,
         most_detailed=True,
         distribution='ensemble',
         population_attributable_fraction_calculation_type='categorical',
-        exposure_exists=True,
-        exposure_standard_deviation_exists=None,
-        exposure_year_type='binned',
-        relative_risk_exists=True,
-        relative_risk_in_range=False,
-        population_attributable_fraction_yll_exists=True,
-        population_attributable_fraction_yll_in_range=True,
-        population_attributable_fraction_yld_exists=True,
-        population_attributable_fraction_yld_in_range=True,
         restrictions=Restrictions(
             male_only=False,
             female_only=False,
@@ -111,7 +80,6 @@ alternative_risk_factors = AlternativeRiskFactors(
             yll_age_group_id_end=5,
             yld_age_group_id_start=4,
             yld_age_group_id_end=5,
-            violated=('exposure_age_restriction_violated', )
         ),
         affected_causes=(causes.all_causes, causes.communicable_maternal_neonatal_and_nutritional_diseases,
                          causes.diarrheal_diseases, causes.lower_respiratory_infections, causes.measles,

--- a/src/vivarium_inputs/mapping_extension/healthcare_entity.py
+++ b/src/vivarium_inputs/mapping_extension/healthcare_entity.py
@@ -1,4 +1,4 @@
-from gbd_mapping.id import meid
+from gbd_mapping.id import me_id
 
 from .healthcare_entity_template import HealthcareEntities, HealthcareEntity
 
@@ -6,13 +6,13 @@ healthcare_entities = HealthcareEntities(
     outpatient_visits=HealthcareEntity(
         name='outpatient_visits',
         kind='healthcare_entity',
-        gbd_id=meid(19797),
-        utilization=meid(19797),
+        gbd_id=me_id(19797),
+        utilization=me_id(19797),
     ),
     inpatient_visits=HealthcareEntity(
         name='inpatient_visits',
         kind='healthcare_entity',
-        gbd_id=meid(18749),
-        utilization=meid(18749),
+        gbd_id=me_id(18749),
+        utilization=me_id(18749),
     )
 )

--- a/src/vivarium_inputs/mapping_extension/healthcare_entity_template.py
+++ b/src/vivarium_inputs/mapping_extension/healthcare_entity_template.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from gbd_mapping.base_template import ModelableEntity, GbdRecord
-from gbd_mapping.id import meid
+from gbd_mapping.id import me_id
 
 
 class HealthcareEntity(ModelableEntity):
@@ -11,8 +11,8 @@ class HealthcareEntity(ModelableEntity):
     def __init__(self,
                  name: str,
                  kind: str,
-                 gbd_id: Union[meid, None],
-                 utilization: meid = None,
+                 gbd_id: Union[me_id, None],
+                 utilization: me_id = None,
                  ):
         super().__init__(name=name, kind=kind, gbd_id=gbd_id)
         self.utilization = utilization

--- a/src/vivarium_inputs/validation/raw.py
+++ b/src/vivarium_inputs/validation/raw.py
@@ -5,7 +5,7 @@ import pandas as pd
 import numpy as np
 from loguru import logger
 
-from gbd_mapping import (ModelableEntity, Cause, Sequela, RiskFactor, Etiology, Covariate, CoverageGap, causes)
+from gbd_mapping import (ModelableEntity, Cause, Sequela, RiskFactor, Etiology, Covariate, causes)
 
 from vivarium_inputs import utility_data
 from vivarium_inputs.globals import (DRAW_COLUMNS, DEMOGRAPHIC_COLUMNS, SEXES, SPECIAL_AGES, METRICS, MEASURES,
@@ -85,7 +85,6 @@ def check_metadata(entity: ModelableEntity, measure: str) -> None:
         'risk_factor': check_risk_factor_metadata,
         'etiology': check_etiology_metadata,
         'covariate': check_covariate_metadata,
-        'coverage_gap': check_coverage_gap_metadata,
         'health_technology': check_health_technology_metadata,
         'healthcare_entity': check_healthcare_entity_metadata,
         'population': check_population_metadata,
@@ -354,10 +353,6 @@ def check_covariate_metadata(entity: Covariate, measure: str) -> None:
         logger.warning(
             f'Covariate {entity.name} may violate the following restrictions: {", ".join(violated_restrictions)}.'
         )
-
-
-def check_coverage_gap_metadata(entity: CoverageGap, measure: str) -> None:
-    pass
 
 
 def check_health_technology_metadata(entity: HealthTechnology, measure: str) -> None:
@@ -691,7 +686,7 @@ def validate_deaths(data: pd.DataFrame, entity: Cause, context: RawValidationCon
                                  value_columns=DRAW_COLUMNS, inclusive=True, error=None)
 
 
-def validate_exposure(data: pd.DataFrame, entity: Union[RiskFactor, CoverageGap, AlternativeRiskFactor],
+def validate_exposure(data: pd.DataFrame, entity: Union[RiskFactor, AlternativeRiskFactor],
                       context: RawValidationContext) -> None:
     """Check the standard set of validations on raw exposure data for entity.
     Check age group and sex ids and restrictions for each category individually
@@ -881,7 +876,7 @@ def validate_exposure_distribution_weights(data: pd.DataFrame, entity: Union[Ris
         raise DataAbnormalError(f'Distribution weights for {entity.kind} {entity.name} do not sum to 1.')
 
 
-def validate_relative_risk(data: pd.DataFrame, entity: Union[RiskFactor, CoverageGap],
+def validate_relative_risk(data: pd.DataFrame, entity: RiskFactor,
                            context: RawValidationContext) -> None:
     """Check the standard set of validations on raw relative risk data for
     entity, replacing the age ids check with a custom check based on the age

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -3,7 +3,7 @@ from typing import Union, Dict, List
 import numpy as np
 import pandas as pd
 
-from gbd_mapping import ModelableEntity, Cause, Sequela, RiskFactor, CoverageGap, Etiology, Covariate, causes
+from gbd_mapping import ModelableEntity, Cause, Sequela, RiskFactor, Etiology, Covariate, causes
 from vivarium_inputs import utilities, utility_data
 from vivarium_inputs.globals import (DataTransformationError, Population,
                                      PROTECTIVE_CAUSE_RISK_PAIRS, BOUNDARY_SPECIAL_CASES, DRAW_COLUMNS)
@@ -411,7 +411,7 @@ def validate_excess_mortality_rate(data: pd.DataFrame, entity: Cause, context: S
     check_sex_restrictions(data, entity.restrictions.male_only, entity.restrictions.female_only, fill_value=0.0)
 
 
-def validate_exposure(data: pd.DataFrame, entity: Union[RiskFactor, CoverageGap, AlternativeRiskFactor],
+def validate_exposure(data: pd.DataFrame, entity: Union[RiskFactor, AlternativeRiskFactor],
                       context: SimulationValidationContext) -> None:
     """Check the standard set of validations on simulation-prepped exposure
     data, with the upper boundary of values determined by the distribution type.
@@ -579,7 +579,7 @@ def validate_exposure_distribution_weights(data: pd.DataFrame, entity: Union[Ris
     check_sex_restrictions(data, entity.restrictions.male_only, entity.restrictions.female_only, fill_value=0.0)
 
 
-def validate_relative_risk(data: pd.DataFrame, entity: Union[RiskFactor, CoverageGap],
+def validate_relative_risk(data: pd.DataFrame, entity: RiskFactor,
                            context: SimulationValidationContext) -> None:
     """Check the standard set of validations on simulation-prepped relative risk
     data, with the upper boundary of values determined by the distribution type.

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -1,0 +1,123 @@
+import numpy as np
+import pandas as pd
+import pytest
+from enum import IntFlag
+
+from gbd_mapping import causes, risk_factors, covariates
+
+from vivarium_inputs import extract, utility_data
+from vivarium_inputs.globals import DataAbnormalError, DataDoesNotExistError, SEXES
+
+
+def success_expected(entity_name, measure_name, location):
+    df = extract.extract_data(entity_name, measure_name, location, validate=False)
+    return df
+
+
+def fail_expected(entity_name, measure_name, location):
+    with pytest.raises(Exception):
+        df = extract.extract_data(entity_name, measure_name, location, validate=True)
+
+
+class MCFlag(IntFlag):
+    INCIDENCE_RATE = 1
+    PREVALENCE = 2
+    BIRTH_PREVALENCE = 4
+    DISABILITY_WEIGHT = 8
+    REMISSION_RATE = 16
+    DEATHS = 32
+    ALL = INCIDENCE_RATE | PREVALENCE | BIRTH_PREVALENCE | DISABILITY_WEIGHT | REMISSION_RATE | DEATHS
+
+
+entity = [
+    (causes.measles, MCFlag.INCIDENCE_RATE
+        | MCFlag.PREVALENCE
+        # TODO need to add folder and files for 2019
+        # | MCFlag.DISABILITY_WEIGHT
+        | MCFlag.DEATHS),
+    (causes.diabetes_mellitus_type_2, MCFlag.INCIDENCE_RATE | MCFlag.PREVALENCE | MCFlag.DEATHS),
+    ]
+measures = [
+    ('incidence_rate', MCFlag.INCIDENCE_RATE),
+    ('prevalence', MCFlag.PREVALENCE),
+    ('birth_prevalence', MCFlag.BIRTH_PREVALENCE),
+    ('disability_weight', MCFlag.DISABILITY_WEIGHT),
+    ('remission_rate', MCFlag.REMISSION_RATE),
+    ('deaths', MCFlag.DEATHS)]
+locations = ['India']
+
+@pytest.mark.parametrize('entity', entity)
+@pytest.mark.parametrize('measure', measures)
+@pytest.mark.parametrize('location', locations)
+def test_extract_causelike(entity, measure, location):
+    entity_name, entity_expected_field = entity
+    measure_name, measure_id = measure
+    tester = success_expected if (entity_expected_field & measure_id) else fail_expected
+    df = tester(entity_name, measure_name, utility_data.get_location_id(location))
+
+
+class MRFlag(IntFlag):
+    EXPOSURE = 1
+    EXPOSURE_SD = 2
+    EXPOSURE_DIST_WEIGHTS = 4
+    RELATIVE_RISK = 8
+    PAF = 16
+    ETIOLOGY_PAF = 32
+    MEDIATION_FACTORS = 64
+    ALL = (EXPOSURE | EXPOSURE_SD | EXPOSURE_DIST_WEIGHTS
+            | RELATIVE_RISK | PAF | ETIOLOGY_PAF | MEDIATION_FACTORS)
+
+
+entity_r = [
+    (risk_factors.high_systolic_blood_pressure,
+        MRFlag.EXPOSURE | MRFlag.EXPOSURE_SD | MRFlag.EXPOSURE_DIST_WEIGHTS
+        | MRFlag.RELATIVE_RISK | MRFlag.PAF | MRFlag.ETIOLOGY_PAF),
+    (risk_factors.low_birth_weight_and_short_gestation,
+        MRFlag.EXPOSURE | MRFlag.RELATIVE_RISK | MRFlag.PAF)]
+measures_r = [
+    ('exposure', MRFlag.EXPOSURE),
+    ('exposure_standard_deviation', MRFlag.EXPOSURE_SD),
+    ('exposure_distribution_weights', MRFlag.EXPOSURE_DIST_WEIGHTS),
+    ('relative_risk', MRFlag.RELATIVE_RISK),
+    ('population_attributable_fraction', MRFlag.PAF),
+    ('etiology_population_attributable_fraction', MRFlag.ETIOLOGY_PAF),
+    ('mediation_factors', MRFlag.MEDIATION_FACTORS)]
+locations_r = ['India']
+@pytest.mark.parametrize('entity', entity_r)
+@pytest.mark.parametrize('measure', measures_r)
+@pytest.mark.parametrize('location', locations_r)
+def test_extract_risklike(entity, measure, location):
+    entity_name, entity_expected_field = entity
+    measure_name, measure_id = measure
+    tester = success_expected if (entity_expected_field & measure_id) else fail_expected
+    df = tester(entity_name, measure_name, utility_data.get_location_id(location))
+
+
+entity_cov = [
+    covariates.systolic_blood_pressure_mmhg,
+]   
+measures_cov = [
+    'estimate'
+]
+locations_cov = ['India']
+@pytest.mark.parametrize('entity', entity_cov)
+@pytest.mark.parametrize('measure', measures_cov)
+@pytest.mark.parametrize('location', locations_cov)
+def test_extract_covariatelike(entity, measure, location):
+    df = extract.extract_data(entity, measure, utility_data.get_location_id(location), validate=False)
+
+
+@pytest.mark.parametrize('measures',
+    [
+        # TODO auxiliary data, needs new 2019 folder
+        #'cost',
+        'utilization_rate'])
+def test_extract_healthsystem(measures):
+    df = extract.extract_data(covariates.medical_schools, measures, utility_data.get_location_id('India'), validate=False)
+
+
+@pytest.mark.parametrize('measures',
+    ['structure',
+    'theoretical_minimum_risk_life_expectancy'])
+def test_extract_population(measures):
+    df = extract.extract_data(None, measures, utility_data.get_location_id('India'), validate=False)

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -5,9 +5,18 @@ import pytest
 from enum import IntFlag
 
 from gbd_mapping import causes, risk_factors, covariates
-
 from vivarium_inputs import extract, utility_data
-from vivarium_inputs.globals import DataAbnormalError, DataDoesNotExistError, SEXES
+
+
+def is_dummy():
+    try:
+        from vivarium_inputs.globals import GbdDummy
+        return True
+    except:
+        pass
+    return False
+
+pytestmark = pytest.mark.skipif(is_dummy(), reason="Don't run these tests on the CI server")
 
 
 def success_expected(entity_name, measure_name, location):

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -1,3 +1,4 @@
+import gbd_mapping
 import numpy as np
 import pandas as pd
 import pytest
@@ -120,4 +121,6 @@ def test_extract_healthsystem(measures):
     ['structure',
     'theoretical_minimum_risk_life_expectancy'])
 def test_extract_population(measures):
-    df = extract.extract_data(None, measures, utility_data.get_location_id('India'), validate=False)
+    from gbd_mapping import ModelableEntity
+    pop = ModelableEntity('ignored', 'population', None)
+    df = extract.extract_data(pop, measures, utility_data.get_location_id('India'), validate=False)


### PR DESCRIPTION
…es. Add new tests (won't run under CI due to how long they take to run)

Changes:

 - remove CoverageGap references
 - modify id types as dictated by changes to gbd_access (covid -> cov_id, meid -> me_id, etc.)
 - remove references to survey data (exposure_exists, exposure_standard_deviation_exists, etc.)
 - remove metadata violation checks
 
Add:
 - quasi-unit-test ./tests/extract/test_extract.py. These tests pull GBD data and some can be quite time consuming.
 
Discussion:
 - We don't want to run the test_extract tests as part of CI. I changed travis-test.sh so that
	the "extract" directory is ignored. Should "extract" be renamed something like "gbd_update"? Is there
	a better way to do this?
 