### PR TITLE
add special case for negative pafs due to child wasting

### DIFF
--- a/src/vivarium_inputs/globals.py
+++ b/src/vivarium_inputs/globals.py
@@ -164,6 +164,7 @@ BOUNDARY_SPECIAL_CASES = {
 
 RISKS_WITH_NEGATIVE_PAF = [
     risk_factors.vitamin_a_deficiency.name,
+    risk_factors.child_wasting.name,
 ]
 
 # residual cat is added by get_draws but all cats modeled for lbwsg so


### PR DESCRIPTION
Tested by successfully building the artifact of `vivarium_ciff_sam` which uses the child wasting risk factor. 