### PR TITLE
Prevent further keyword FutureWarnings when running make_artifacts

### DIFF
--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -126,7 +126,7 @@ def get_disability_weight(entity: Union[Cause, Sequela], location_id: int) -> pd
                     # sequela prevalence does not exist so no point continuing with this sequela
                     continue
                 disability = get_data(sequela, 'disability_weight', location_id)
-                disability.index = disability.index.set_levels([location_id], 'location_id')
+                disability.index = disability.index.set_levels([location_id], level='location_id')
                 data += prevalence * disability
         cause_prevalence = get_data(entity, 'prevalence', location_id)
         data = (data / cause_prevalence).fillna(0).reset_index()
@@ -376,7 +376,7 @@ def get_utilization_rate(entity: HealthcareEntity, location_id: int) -> pd.DataF
 
 def get_structure(entity: Population, location_id: int) -> pd.DataFrame:
     data = extract.extract_data(entity, 'structure', location_id)
-    data = data.drop('run_id', 'columns').rename(columns={'population': 'value'})
+    data = data.drop('run_id', axis='columns').rename(columns={'population': 'value'})
     data = utilities.normalize(data)
     return data
 

--- a/src/vivarium_inputs/utilities.py
+++ b/src/vivarium_inputs/utilities.py
@@ -27,7 +27,7 @@ def scrub_gbd_conventions(data, location):
 
 def scrub_location(data, location):
     if 'location_id' in data.index.names:
-        data.index = data.index.rename('location', 'location_id').set_levels([location], 'location')
+        data.index = data.index.rename('location', level='location_id').set_levels([location], level='location')
     else:
         data = pd.concat([data], keys=[location], names=['location'])
     return data
@@ -36,7 +36,7 @@ def scrub_location(data, location):
 def scrub_sex(data):
     if 'sex_id' in data.index.names:
         levels = list(data.index.levels[data.index.names.index('sex_id')].map(lambda x: {1: 'Male', 2: 'Female'}.get(x, x)))
-        data.index = data.index.rename('sex', 'sex_id').set_levels(levels, 'sex')
+        data.index = data.index.rename('sex', level='sex_id').set_levels(levels, level='sex')
     return data
 
 
@@ -46,7 +46,7 @@ def scrub_age(data):
         id_levels = data.index.levels[data.index.names.index('age_group_id')]
         interval_levels = [pd.Interval(age_bins.age_start[age_id],
                                        age_bins.age_end[age_id], closed='left') for age_id in id_levels]
-        data.index = data.index.rename('age', 'age_group_id').set_levels(interval_levels, 'age')
+        data.index = data.index.rename('age', level='age_group_id').set_levels(interval_levels, level='age')
     return data
 
 
@@ -54,7 +54,7 @@ def scrub_year(data):
     if 'year_id' in data.index.names:
         id_levels = data.index.levels[data.index.names.index('year_id')]
         interval_levels = [pd.Interval(year_id, year_id + 1, closed='left') for year_id in id_levels]
-        data.index = data.index.rename('year', 'year_id').set_levels(interval_levels, 'year')
+        data.index = data.index.rename('year', level='year_id').set_levels(interval_levels, level='year')
     return data
 
 
@@ -408,7 +408,7 @@ def split_interval(data, interval_column, split_column_prefix):
             data = data.set_index([f'{split_column_prefix}_start', f'{split_column_prefix}_end'])
         else:
             interval_starts = [x.left for x in data.index.levels[data.index.names.index(interval_column)]]
-            data.index = (data.index.rename(f'{split_column_prefix}_start', interval_column)
-                          .set_levels(interval_starts, f'{split_column_prefix}_start'))
+            data.index = (data.index.rename(f'{split_column_prefix}_start', level=interval_column)
+                          .set_levels(interval_starts, level=f'{split_column_prefix}_start'))
             data = data.set_index(f'{split_column_prefix}_end', append=True)
     return data


### PR DESCRIPTION
##  Prevent keyword FutureWarnings when running make_artifacts


###  Description

- *Category*: bugfix

- *JIRA issue*:  [MIC-2702](https://jira.ihme.washington.edu/browse/MIC-2707) 

Duplicate of [this pull request](https://github.com/ihmeuw/vivarium_inputs/pull/281). More FutureWarnings appeared when running make_artifacts after fixing [this bug](https://jira.ihme.washington.edu/browse/MIC-2816) but by the time I saw them I had already deleted the branch for the closed pull request.

  

###  Testing

Relevant warnings don't appear when running make_artifacts.
