### PR TITLE
Feature/update paf standard call

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,7 +82,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -234,7 +234,7 @@ def extract_relative_risk(entity: RiskFactor, location_id: int) -> pd.DataFrame:
 
 
 def extract_population_attributable_fraction(entity: Union[RiskFactor, Etiology], location_id: int) -> pd.DataFrame:
-    data = gbd.get_paf(entity.gbd_id, location_id).drop('version_id')
+    data = gbd.get_paf(entity.gbd_id, location_id).drop(columns=['version_id'])
     data = data[data.metric_id == METRICS['Percent']]
     data = data[data.measure_id.isin([MEASURES['YLDs'], MEASURES['YLLs']])]
     data = filter_to_most_detailed_causes(data)

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -227,16 +227,16 @@ def extract_exposure_distribution_weights(
 
 def extract_relative_risk(entity: RiskFactor, location_id: int) -> pd.DataFrame:
     data = gbd.get_relative_risk(entity.gbd_id, location_id)
+    if 'model_version_id' in data.columns:
+        data = data.drop(columns=['model_version_id'])
     data = filter_to_most_detailed_causes(data)
     return data
 
 
-def extract_population_attributable_fraction(
-    entity: Union[RiskFactor, Etiology], location_id: int
-) -> pd.DataFrame:
-    data = gbd.get_paf(entity.gbd_id, location_id)
-    data = data[data.metric_id == METRICS["Percent"]]
-    data = data[data.measure_id.isin([MEASURES["YLDs"], MEASURES["YLLs"]])]
+def extract_population_attributable_fraction(entity: Union[RiskFactor, Etiology], location_id: int) -> pd.DataFrame:
+    data = gbd.get_paf(entity.gbd_id, location_id).drop('version_id')
+    data = data[data.metric_id == METRICS['Percent']]
+    data = data[data.measure_id.isin([MEASURES['YLDs'], MEASURES['YLLs']])]
     data = filter_to_most_detailed_causes(data)
     return data
 

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -227,16 +227,18 @@ def extract_exposure_distribution_weights(
 
 def extract_relative_risk(entity: RiskFactor, location_id: int) -> pd.DataFrame:
     data = gbd.get_relative_risk(entity.gbd_id, location_id)
-    if 'model_version_id' in data.columns:
-        data = data.drop(columns=['model_version_id'])
+    if "model_version_id" in data.columns:
+        data = data.drop(columns=["model_version_id"])
     data = filter_to_most_detailed_causes(data)
     return data
 
 
-def extract_population_attributable_fraction(entity: Union[RiskFactor, Etiology], location_id: int) -> pd.DataFrame:
-    data = gbd.get_paf(entity.gbd_id, location_id).drop(columns=['version_id'])
-    data = data[data.metric_id == METRICS['Percent']]
-    data = data[data.measure_id.isin([MEASURES['YLDs'], MEASURES['YLLs']])]
+def extract_population_attributable_fraction(
+    entity: Union[RiskFactor, Etiology], location_id: int
+) -> pd.DataFrame:
+    data = gbd.get_paf(entity.gbd_id, location_id).drop(columns=["version_id"])
+    data = data[data.metric_id == METRICS["Percent"]]
+    data = data[data.measure_id.isin([MEASURES["YLDs"], MEASURES["YLLs"]])]
     data = filter_to_most_detailed_causes(data)
     return data
 


### PR DESCRIPTION
## Title: Update PAF call for load_standard_data

### Description
Updated calls for PAF and RR for load_standard_data to be compatible with newer version of get_draws.
- *Category*: Other
- *JIRA issue*: [MIC-3184](https://jira.ihme.washington.edu/browse/MIC-3184)

Updated PAF and RR to drop new columns being created by newer version of get_draws (4.8.0).  Had to account for get_draws behavior creating a column for RR for certain location levels but not others.

### Testing
Testing get_draws and load_standard_data in a notebook.  Was able to successfully pull PAF and RR data with load_standard_data function with no errors.

