### PR TITLE
Feature/sbachmei/mic 3233 update get draws validation approach

### DIFF
--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -8,7 +8,9 @@ from loguru import logger
 
 from vivarium_inputs import extract, utilities, utility_data
 from vivarium_inputs.globals import (
+    COVARIATE_VALUE_COLUMNS, 
     DEMOGRAPHIC_COLUMNS,
+    DISTRIBUTION_COLUMNS,
     DRAW_COLUMNS,
     EXTRA_RESIDUAL_CATEGORY,
     MEASURES,
@@ -18,23 +20,6 @@ from vivarium_inputs.globals import (
     Population,
 )
 from vivarium_inputs.mapping_extension import AlternativeRiskFactor, HealthcareEntity
-
-DISTRIBUTION_COLUMNS = [
-    "exp",
-    "gamma",
-    "invgamma",
-    "llogis",
-    "gumbel",
-    "invweibull",
-    "weibull",
-    "lnorm",
-    "norm",
-    "glnorm",
-    "betasr",
-    "mgamma",
-    "mgumbel",
-]
-COVARIATE_VALUE_COLUMNS = ["mean_value", "upper_value", "lower_value"]
 
 
 def get_data(entity, measure: str, location: Union[str, int]):
@@ -306,9 +291,7 @@ def get_exposure_distribution_weights(
         df.append(copied)
     data = pd.concat(df)
     data = utilities.normalize(data, fill_value=0, cols_to_fill=DISTRIBUTION_COLUMNS)
-    data = data.filter(
-        ["location_id", "sex_id", "age_group_id", "year_id"] + DISTRIBUTION_COLUMNS
-    )
+    data = data.filter(DEMOGRAPHIC_COLUMNS + DISTRIBUTION_COLUMNS)
     data = utilities.wide_to_long(data, DISTRIBUTION_COLUMNS, var_name="parameter")
     return data
 

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 from vivarium_inputs import extract, utilities, utility_data
 from vivarium_inputs.globals import (
-    COVARIATE_VALUE_COLUMNS, 
+    COVARIATE_VALUE_COLUMNS,
     DEMOGRAPHIC_COLUMNS,
     DISTRIBUTION_COLUMNS,
     DRAW_COLUMNS,

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -227,8 +227,6 @@ def extract_exposure_distribution_weights(
 
 def extract_relative_risk(entity: RiskFactor, location_id: int) -> pd.DataFrame:
     data = gbd.get_relative_risk(entity.gbd_id, location_id)
-    if "model_version_id" in data.columns:
-        data = data.drop(columns=["model_version_id"])
     data = filter_to_most_detailed_causes(data)
     return data
 
@@ -236,7 +234,7 @@ def extract_relative_risk(entity: RiskFactor, location_id: int) -> pd.DataFrame:
 def extract_population_attributable_fraction(
     entity: Union[RiskFactor, Etiology], location_id: int
 ) -> pd.DataFrame:
-    data = gbd.get_paf(entity.gbd_id, location_id).drop(columns=["version_id"])
+    data = gbd.get_paf(entity.gbd_id, location_id)
     data = data[data.metric_id == METRICS["Percent"]]
     data = data[data.measure_id.isin([MEASURES["YLDs"], MEASURES["YLLs"]])]
     data = filter_to_most_detailed_causes(data)

--- a/src/vivarium_inputs/globals.py
+++ b/src/vivarium_inputs/globals.py
@@ -130,6 +130,24 @@ MEASURES = {
     "Fertility": 45,
 }
 
+# List of standard distribution columns
+DISTRIBUTION_COLUMNS = [
+    "exp",
+    "gamma",
+    "invgamma",
+    "llogis",
+    "gumbel",
+    "invweibull",
+    "weibull",
+    "lnorm",
+    "norm",
+    "glnorm",
+    "betasr",
+    "mgamma",
+    "mgumbel",
+]
+# List of standard covariate values
+COVARIATE_VALUE_COLUMNS = ["mean_value", "upper_value", "lower_value"]
 # List of standard demographic id column names.
 DEMOGRAPHIC_COLUMNS = ["location_id", "sex_id", "age_group_id", "year_id"]
 # List of standard GBD draw column names.

--- a/src/vivarium_inputs/validation/raw.py
+++ b/src/vivarium_inputs/validation/raw.py
@@ -1983,6 +1983,10 @@ def check_columns(expected_cols: List, existing_cols: List) -> None:
     DataAbnormalError
         If any `expected_cols` are missing from `existing_cols`.
 
+    Warns
+    ------
+    - If `existing_colums` contains column names not found in `expected_columns`
+
     """
     if set(existing_cols) < set(expected_cols):
         raise DataAbnormalError(

--- a/src/vivarium_inputs/validation/raw.py
+++ b/src/vivarium_inputs/validation/raw.py
@@ -1989,7 +1989,9 @@ def check_columns(expected_cols: List, existing_cols: List) -> None:
             f"Data is missing columns: {set(expected_cols).difference(set(existing_cols))}."
         )
     elif set(existing_cols) > set(expected_cols):
-        logger.warning(f"Data returned extra columns: {set(existing_cols).difference(set(expected_cols))}.")
+        logger.warning(
+            f"Data returned extra columns: {set(existing_cols).difference(set(expected_cols))}."
+        )
 
 
 def check_data_exist(

--- a/src/vivarium_inputs/validation/raw.py
+++ b/src/vivarium_inputs/validation/raw.py
@@ -1981,7 +1981,7 @@ def check_columns(expected_cols: List, existing_cols: List) -> None:
     Raises
     ------
     DataAbnormalError
-        If `expected_cols` does not match `existing_cols`.
+        If any `expected_cols` are missing from `existing_cols`.
 
     """
     if set(existing_cols) < set(expected_cols):
@@ -1989,9 +1989,7 @@ def check_columns(expected_cols: List, existing_cols: List) -> None:
             f"Data is missing columns: {set(expected_cols).difference(set(existing_cols))}."
         )
     elif set(existing_cols) > set(expected_cols):
-        raise DataAbnormalError(
-            f"Data returned extra columns: {set(existing_cols).difference(set(expected_cols))}."
-        )
+        logger.warning(f"Data returned extra columns: {set(existing_cols).difference(set(expected_cols))}.")
 
 
 def check_data_exist(

--- a/tests/validation/test_raw.py
+++ b/tests/validation/test_raw.py
@@ -133,12 +133,6 @@ def test_check_columns_pass(columns):
     raw.check_columns(columns, columns)
 
 
-@pytest.mark.parametrize("columns", [["a", "b"], ["c", "d", "e"], ["a"], []])
-def test_check_columns_extra_fail(columns):
-    with pytest.raises(DataAbnormalError, match="extra columns"):
-        raw.check_columns(columns, columns + ["extra"])
-
-
 @pytest.mark.parametrize("columns", [["a", "b"], ["c", "d", "e"], ["a"]])
 def test_check_columns_missing_fail(columns):
     with pytest.raises(DataAbnormalError, match="missing columns"):

--- a/tests/validation/test_raw.py
+++ b/tests/validation/test_raw.py
@@ -133,6 +133,12 @@ def test_check_columns_pass(columns):
     raw.check_columns(columns, columns)
 
 
+@pytest.mark.parametrize("columns", [["a", "b"], ["c", "d", "e"], ["a"], []])
+def test_check_columns_extra_fail(columns):
+    with pytest.raises(DataAbnormalError, match="extra columns"):
+        raw.check_columns(columns, columns + ["extra"])
+
+
 @pytest.mark.parametrize("columns", [["a", "b"], ["c", "d", "e"], ["a"]])
 def test_check_columns_missing_fail(columns):
     with pytest.raises(DataAbnormalError, match="missing columns"):

--- a/tests/validation/test_raw.py
+++ b/tests/validation/test_raw.py
@@ -134,9 +134,9 @@ def test_check_columns_pass(columns):
 
 
 @pytest.mark.parametrize("columns", [["a", "b"], ["c", "d", "e"], ["a"], []])
-def test_check_columns_extra_fail(columns):
-    with pytest.raises(DataAbnormalError, match="extra columns"):
-        raw.check_columns(columns, columns + ["extra"])
+def test_check_columns_extra_warn(columns, caplog, match="Data returned extra columns"):
+    raw.check_columns(columns, columns + ["extra"])
+    assert match in caplog.text
 
 
 @pytest.mark.parametrize("columns", [["a", "b"], ["c", "d", "e"], ["a"]])


### PR DESCRIPTION
## Title: Allow for extra columns to be returned

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3233](https://jira.ihme.washington.edu/browse/MIC-3233)

`get_draws` began returning extra columns which led to a
`raise DataAbnormalError`. In reality, this is fine to have extra columns
floating around as they tend to get filtered away anyway.

Just log the extra columns instead of raising.

While I was poking around in there, I moved DISTRIBUTION_COLUMNS 
and COVARIATE_VALUE_COLUMNS from `vivarium_inputs/core.py` 
to `vivarium_inputs/globals.py`. lmk if external repos call these
objects and I'll revert.

### Testing
I several of the `vivarium_inputs.core.get_*` calls

