### PR TITLE
Dropping model_version_id column due to bug when pulling exposure data

### DIFF
--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -220,7 +220,7 @@ def get_exposure(
     entity: Union[RiskFactor, AlternativeRiskFactor], location_id: int
 ) -> pd.DataFrame:
     data = extract.extract_data(entity, "exposure", location_id)
-    data = data.drop("modelable_entity_id", "columns")
+    data = data.drop(["modelable_entity_id", "model_version_id"], "columns")
 
     if entity.name in EXTRA_RESIDUAL_CATEGORY:
         cat = EXTRA_RESIDUAL_CATEGORY[entity.name]

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -223,7 +223,7 @@ def get_exposure(
     data = data.drop("modelable_entity_id", "columns")
     # Fixme: why are different level locations carrying this column along?
     if "model_version_id" in data.columns:
-        data.drop("model_version_id", "columns")
+        data = data.drop("model_version_id", "columns")
 
     if entity.name in EXTRA_RESIDUAL_CATEGORY:
         cat = EXTRA_RESIDUAL_CATEGORY[entity.name]

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -220,7 +220,10 @@ def get_exposure(
     entity: Union[RiskFactor, AlternativeRiskFactor], location_id: int
 ) -> pd.DataFrame:
     data = extract.extract_data(entity, "exposure", location_id)
-    data = data.drop(["modelable_entity_id", "model_version_id"], "columns")
+    data = data.drop("modelable_entity_id", "columns")
+    # Fixme: why are different level locations caryring this column along?
+    if "model_version_i" in data.columns:
+        data.drop("model_version_id", "columns")
 
     if entity.name in EXTRA_RESIDUAL_CATEGORY:
         cat = EXTRA_RESIDUAL_CATEGORY[entity.name]

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -215,6 +215,7 @@ def get_exposure(
 ) -> pd.DataFrame:
     data = extract.extract_data(entity, "exposure", location_id)
     data = data.drop("modelable_entity_id", "columns")
+
     # Fixme: why are different level locations carrying this column along?
     if "model_version_id" in data.columns:
         data = data.drop("model_version_id", "columns")

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -35,13 +35,7 @@ def get_data(entity, measure: str, location: Union[str, int]):
         "excess_mortality_rate": (get_excess_mortality_rate, ("cause",)),
         "deaths": (get_deaths, ("cause",)),
         # Risk-like measures
-        "exposure": (
-            get_exposure,
-            (
-                "risk_factor",
-                "alternative_risk_factor",
-            ),
-        ),
+        "exposure": (get_exposure, ("risk_factor", "alternative_risk_factor")),
         "exposure_standard_deviation": (
             get_exposure_standard_deviation,
             ("risk_factor", "alternative_risk_factor"),

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -222,7 +222,7 @@ def get_exposure(
     data = extract.extract_data(entity, "exposure", location_id)
     data = data.drop("modelable_entity_id", "columns")
     # Fixme: why are different level locations caryring this column along?
-    if "model_version_i" in data.columns:
+    if "model_version_id" in data.columns:
         data.drop("model_version_id", "columns")
 
     if entity.name in EXTRA_RESIDUAL_CATEGORY:

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -221,7 +221,7 @@ def get_exposure(
 ) -> pd.DataFrame:
     data = extract.extract_data(entity, "exposure", location_id)
     data = data.drop("modelable_entity_id", "columns")
-    # Fixme: why are different level locations caryring this column along?
+    # Fixme: why are different level locations carrying this column along?
     if "model_version_id" in data.columns:
         data.drop("model_version_id", "columns")
 


### PR DESCRIPTION
## Bugfix/exposure extractor function breaking because of extra column.

### Description
Calling get_standard_data to pull child stunting exposure was breaking due to the handling of model_version_id in the exposure extractor function.
- *Category*: Bugfix
- *JIRA issue*: [MIC-3316](https://jira.ihme.washington.edu/browse/MIC-3316)

The column model_version_id was added to columns to get dropped from the returned data frame.

### Testing
Successfully wrote artifacts for multiple locations.

