### PR TITLE
Feature/sbachmei/mic 3601 high bmi negative paf

### DIFF
--- a/src/vivarium_inputs/globals.py
+++ b/src/vivarium_inputs/globals.py
@@ -182,6 +182,7 @@ BOUNDARY_SPECIAL_CASES = {
 RISKS_WITH_NEGATIVE_PAF = [
     risk_factors.vitamin_a_deficiency.name,
     risk_factors.child_wasting.name,
+    risk_factors.high_body_mass_index_in_adults.name,
 ]
 
 # residual cat is added by get_draws but all cats modeled for lbwsg so


### PR DESCRIPTION
## Title: Allow negative paf for high bmi in adults

### Description
- *Category*: feature
- *JIRA issue*: [MIC-3601](https://jira.ihme.washington.edu/browse/MIC-3601)

### Changes and notes
Data validation checks for negative paf and throws an error unless
a given risk is included in an explicit list of risks that have negative
PAFs. This adds "high_body_mass_index_in_adults" to that
list.

### Testing
Confirmed that the bmi PAF data is loaded and saved to the artifact.

