### PR TITLE
fix pytests

### DIFF
--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -251,7 +251,8 @@ def get_exposure(
         sums = data.groupby(cols)[DRAW_COLUMNS].sum()
         data = (
             data.groupby("parameter")
-            .apply(lambda df: df.set_index(cols).loc[:, DRAW_COLUMNS].divide(sums))
+            .apply(lambda df: df.set_index(cols)[DRAW_COLUMNS].divide(sums.replace(0, 1)))
+            .dropna(axis=0, how="all")
             .reset_index()
         )
     else:

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -24,7 +24,7 @@ def success_expected(entity_name, measure_name, location):
 
 def fail_expected(entity_name, measure_name, location):
     with pytest.raises(Exception):
-        df = extract.extract_data(entity_name, measure_name, location, validate=VALIDATE_FLAG)
+        df = extract.extract_data(entity_name, measure_name, location, validate=True)
 
 
 class MCFlag(IntFlag):


### PR DESCRIPTION
## Fix failing pytests

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3610](https://jira.ihme.washington.edu/browse/MIC-3610)

### Changes and notes
There are two (possibly long-existing) failing pytests:

1. `tests/extract/test_extract.py - test_extract_causelike[Indea-remissio_rate-diabetes_mellitus_type_2] FAILED [ 22%]`
2. `tests/extract/test_get_measure.py::test_get_measure_risklike[India-exposure-low_birth_weight_and_short_gestation] FAILED [ 38%]`

For the first, the issue was that the pytest was using extract_data(..., validate=False) which would skip the step that validates that the dataset is non-empty.

For the second, the issue is that
1. All-zero draws result in NaN when normalizing (b/c divide-by-zero)(
2. different-shaped `data` and `sums` results in all-NaN rows when data.divide(sums)

### Testing
pytests pass

