### PR TITLE
add tool.isort known_third_party list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,4 @@ exclude = '''
 [tool.isort]
 profile = "black"
 skip = ["vivarium", "vivarium_public_health", "gbd_mapping"]
+known_third_party = ["vivarium", "vivarium_public_health", "gbd_mapping"]


### PR DESCRIPTION
## Title: Bugfix ci isort

### Description
- *Category*: bugfix
- *JIRA issue*: na

### Changes and notes
When attempting to release vivarium_inputs, the builds started failing on isort.
No changes were needed when running isort locally. I happened to notice that
James had added a `known_third_party` list to the pyproject.toml for 
the vivarium_public_health repo (https://github.com/ihmeuw/vivarium_public_health/blob/main/pyproject.toml#L13)
I naively tried that and it seems to work.

### Testing
passes builds

