### PR TITLE
Mic-4379/Add schedule builds to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,14 @@
 # -----------------------------------------------------------------------------
-#   Continuous Intergration for Vivarium Inputs
-#   - invoked on push and pull_request
+#   - invoked on push, pull_request, manual trigger, or schedule
 #   - test under at least 3 versions of python
-#   - look for upstream branches and use if they exist
 # -----------------------------------------------------------------------------
 name: build
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
## Mic-4379/add schedule builds to CI

### Adds nightly builds to github actions
- *Category*: CI
- *JIRA issue*: [MIC-4379](https://jira.ihme.washington.edu/browse/MIC-4379)

### Changes and notes
-Adds scheduled build to github actions to run at 1AM

### Testing
All tests pass

