### PR TITLE
Mic-4617/Drop support for 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash -le {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Install hdf5 libs
         run: |
+          sudo apt-get update
           sudo apt-get install libhdf5-dev
       
       - name: get upstream branch name

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,6 @@
+**4.1.2 - 10/16/23**
+ - Drop support for python 3.8
+
 **4.1.1 - 07/13/23**
 
  - Update pins

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -193,7 +193,7 @@ texinfo_documents = [
 
 # Other docs we can link to
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.8", None),
+    "python": ("https://docs.python.org/3.11", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "tables": ("https://www.pytables.org/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),


### PR DESCRIPTION
## Mic-4617/Drop support for 3.8

### Drop support for python 3.8
- *Category*: CI
- *JIRA issue*: [MIC-4617](https://jira.ihme.washington.edu/browse/MIC-XYZ)

### Changes and notes
-drops support for python 3.8

### Testing
Will check schedule workflow runs successfully.

