### PR TITLE
add year ID option to vivarium inputs

### DIFF
--- a/docs/source/tutorials/pulling_data.rst
+++ b/docs/source/tutorials/pulling_data.rst
@@ -381,10 +381,11 @@ To use:
                     'measure': str, 
                     'location': Union[int, str, List[Union[int, str]]],
                     'get_all_years': bool,
+                    'year_id': int,
                         },
                 'return': pd.DataFrame, },
              get_population_structure: {
-                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'get_all_years': bool},
+                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'get_all_years': bool, 'year_id': int},
                  'return': pd.DataFrame, },
              get_theoretical_minimum_risk_life_expectancy: {
                  'parameters': {},
@@ -393,7 +394,7 @@ To use:
                  'parameters': {},
                  'return': pd.DataFrame, },
              get_demographic_dimensions: {
-                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'get_all_years': bool},
+                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'get_all_years': bool, 'year_id': int},
                  'return': pd.DataFrame, },
              get_raw_data: {
                  'parameters': {
@@ -401,6 +402,7 @@ To use:
                     'measure': str,
                     'location': Union[int, str, List[Union[int, str]]],
                     'get_all_years': bool,
+                    'year_id': int,
                         },
                 'return': Union[pd.DataFrame, pd.Series], },
              }

--- a/docs/source/tutorials/pulling_data.rst
+++ b/docs/source/tutorials/pulling_data.rst
@@ -366,7 +366,7 @@ To use:
     :hide:
 
     import inspect
-    from typing import List, Union
+    from typing import List, Optional, Union
 
     import pandas as pd
 
@@ -381,11 +381,11 @@ To use:
                     'measure': str, 
                     'location': Union[int, str, List[Union[int, str]]],
                     'get_all_years': bool,
-                    'year_id': int,
+                    'year_id': Optional[int],
                         },
                 'return': pd.DataFrame, },
              get_population_structure: {
-                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'get_all_years': bool, 'year_id': int},
+                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'get_all_years': bool, 'year_id': Optional[int]},
                  'return': pd.DataFrame, },
              get_theoretical_minimum_risk_life_expectancy: {
                  'parameters': {},
@@ -394,7 +394,7 @@ To use:
                  'parameters': {},
                  'return': pd.DataFrame, },
              get_demographic_dimensions: {
-                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'get_all_years': bool, 'year_id': int},
+                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'get_all_years': bool, 'year_id': Optional[int]},
                  'return': pd.DataFrame, },
              get_raw_data: {
                  'parameters': {
@@ -402,7 +402,7 @@ To use:
                     'measure': str,
                     'location': Union[int, str, List[Union[int, str]]],
                     'get_all_years': bool,
-                    'year_id': int,
+                    'year_id': Optional[int],
                         },
                 'return': Union[pd.DataFrame, pd.Series], },
              }

--- a/docs/source/tutorials/pulling_data.rst
+++ b/docs/source/tutorials/pulling_data.rst
@@ -380,11 +380,11 @@ To use:
                     'entity': ModelableEntity, 
                     'measure': str, 
                     'location': Union[int, str, List[Union[int, str]]],
-                    'year_id': Optional[Union[int, str, List[int]]],
+                    'years': Optional[Union[int, str, List[int]]],
                         },
                 'return': pd.DataFrame, },
              get_population_structure: {
-                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'year_id': Optional[Union[int, str, List[int]]]},
+                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'years': Optional[Union[int, str, List[int]]]},
                  'return': pd.DataFrame, },
              get_theoretical_minimum_risk_life_expectancy: {
                  'parameters': {},
@@ -393,14 +393,14 @@ To use:
                  'parameters': {},
                  'return': pd.DataFrame, },
              get_demographic_dimensions: {
-                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'year_id': Optional[Union[int, str, List[int]]]},
+                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'years': Optional[Union[int, str, List[int]]]},
                  'return': pd.DataFrame, },
              get_raw_data: {
                  'parameters': {
                     'entity': ModelableEntity,
                     'measure': str,
                     'location': Union[int, str, List[Union[int, str]]],
-                    'year_id': Optional[Union[int, str, List[int]]],
+                    'years': Optional[Union[int, str, List[int]]],
                         },
                 'return': Union[pd.DataFrame, pd.Series], },
              }

--- a/docs/source/tutorials/pulling_data.rst
+++ b/docs/source/tutorials/pulling_data.rst
@@ -380,12 +380,11 @@ To use:
                     'entity': ModelableEntity, 
                     'measure': str, 
                     'location': Union[int, str, List[Union[int, str]]],
-                    'get_all_years': bool,
-                    'year_id': Optional[int],
+                    'year_id': Optional[Union[int, str, List[int]]],
                         },
                 'return': pd.DataFrame, },
              get_population_structure: {
-                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'get_all_years': bool, 'year_id': Optional[int]},
+                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'year_id': Optional[Union[int, str, List[int]]]},
                  'return': pd.DataFrame, },
              get_theoretical_minimum_risk_life_expectancy: {
                  'parameters': {},
@@ -394,15 +393,14 @@ To use:
                  'parameters': {},
                  'return': pd.DataFrame, },
              get_demographic_dimensions: {
-                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'get_all_years': bool, 'year_id': Optional[int]},
+                 'parameters': {'location': Union[int, str, List[Union[int, str]]], 'year_id': Optional[Union[int, str, List[int]]]},
                  'return': pd.DataFrame, },
              get_raw_data: {
                  'parameters': {
                     'entity': ModelableEntity,
                     'measure': str,
                     'location': Union[int, str, List[Union[int, str]]],
-                    'get_all_years': bool,
-                    'year_id': Optional[int],
+                    'year_id': Optional[Union[int, str, List[int]]],
                         },
                 'return': Union[pd.DataFrame, pd.Series], },
              }

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -444,10 +444,10 @@ def get_exposure_distribution_weights(
     data = utilities.normalize(data, fill_value=0, cols_to_fill=DISTRIBUTION_COLUMNS)
     if years != "all":
         if years:
-            data = data.query(f"years=={years}")
+            data = data.query(f"year_id=={years}")
         else:
             most_recent_year = gbd.get_most_recent_year()
-            data = data.query(f"years=={most_recent_year}")
+            data = data.query(f"year_id=={most_recent_year}")
     data = data.filter(DEMOGRAPHIC_COLUMNS + DISTRIBUTION_COLUMNS)
     data = utilities.wide_to_long(data, DISTRIBUTION_COLUMNS, var_name="parameter")
     return data

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -119,10 +119,18 @@ def get_data(
 
 
 def get_raw_incidence_rate(
-    entity: Union[Cause, Sequela], location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Union[Cause, Sequela],
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
-        entity, "incidence_rate", location_id, validate=True, get_all_years=get_all_years, year_id=year_id
+        entity,
+        "incidence_rate",
+        location_id,
+        validate=True,
+        get_all_years=get_all_years,
+        year_id=year_id,
     )
     if entity.kind == "cause":
         restrictions_entity = entity
@@ -139,20 +147,39 @@ def get_raw_incidence_rate(
 
 
 def get_incidence_rate(
-    entity: Union[Cause, Sequela], location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Union[Cause, Sequela],
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
-    data = get_data(entity, "raw_incidence_rate", location_id, get_all_years=get_all_years, year_id=year_id)
-    prevalence = get_data(entity, "prevalence", location_id, get_all_years=get_all_years, year_id=year_id)
+    data = get_data(
+        entity,
+        "raw_incidence_rate",
+        location_id,
+        get_all_years=get_all_years,
+        year_id=year_id,
+    )
+    prevalence = get_data(
+        entity, "prevalence", location_id, get_all_years=get_all_years, year_id=year_id
+    )
     # Convert from "True incidence" to the incidence rate among susceptibles
     data /= 1 - prevalence
     return data.fillna(0)
 
 
 def get_prevalence(
-    entity: Union[Cause, Sequela], location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Union[Cause, Sequela],
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
-        entity, "prevalence", location_id, validate=True, get_all_years=get_all_years, year_id=year_id
+        entity,
+        "prevalence",
+        location_id,
+        validate=True,
+        get_all_years=get_all_years,
+        year_id=year_id,
     )
     if entity.kind == "cause":
         restrictions_entity = entity
@@ -169,10 +196,18 @@ def get_prevalence(
 
 
 def get_birth_prevalence(
-    entity: Union[Cause, Sequela], location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Union[Cause, Sequela],
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
-        entity, "birth_prevalence", location_id, validate=True, get_all_years=get_all_years, year_id=year_id
+        entity,
+        "birth_prevalence",
+        location_id,
+        validate=True,
+        get_all_years=get_all_years,
+        year_id=year_id,
     )
     data = data.filter(["year_id", "sex_id", "location_id"] + DRAW_COLUMNS)
     data = utilities.normalize(data, fill_value=0)
@@ -180,14 +215,17 @@ def get_birth_prevalence(
 
 
 def get_disability_weight(
-    entity: Union[Cause, Sequela], location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Union[Cause, Sequela],
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     if entity.kind == "cause":
         data = utility_data.get_demographic_dimensions(
             location_id, get_all_years, draws=True, value=0.0
         )
         if year_id:
-            data['year_id'] = year_id
+            data["year_id"] = year_id
         data = data.set_index(
             utilities.get_ordered_index_cols(data.columns.difference(DRAW_COLUMNS))
         )
@@ -195,13 +233,21 @@ def get_disability_weight(
             for sequela in entity.sequelae:
                 try:
                     prevalence = get_data(
-                        sequela, "prevalence", location_id, get_all_years=get_all_years, year_id=year_id
+                        sequela,
+                        "prevalence",
+                        location_id,
+                        get_all_years=get_all_years,
+                        year_id=year_id,
                     )
                 except DataDoesNotExistError:
                     # sequela prevalence does not exist so no point continuing with this sequela
                     continue
                 disability = get_data(
-                    sequela, "disability_weight", location_id, get_all_years=get_all_years, year_id=year_id
+                    sequela,
+                    "disability_weight",
+                    location_id,
+                    get_all_years=get_all_years,
+                    year_id=year_id,
                 )
                 data += prevalence * disability
         cause_prevalence = get_data(
@@ -236,10 +282,18 @@ def get_disability_weight(
 
 
 def get_remission_rate(
-    entity: Cause, location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Cause,
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
-        entity, "remission_rate", location_id, validate=True, get_all_years=get_all_years, year_id=year_id
+        entity,
+        "remission_rate",
+        location_id,
+        validate=True,
+        get_all_years=get_all_years,
+        year_id=year_id,
     )
     data = utilities.filter_data_by_restrictions(
         data, entity, "yld", utility_data.get_age_group_ids()
@@ -250,34 +304,56 @@ def get_remission_rate(
 
 
 def get_cause_specific_mortality_rate(
-    entity: Cause, location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Cause,
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     deaths = get_data(
         entity, "deaths", location_id, get_all_years=get_all_years, year_id=year_id
     )  # population isn't by draws
-    pop = get_data(Population(), "structure", location_id, get_all_years=get_all_years, year_id=year_id)
+    pop = get_data(
+        Population(), "structure", location_id, get_all_years=get_all_years, year_id=year_id
+    )
     data = deaths.join(pop, lsuffix="_deaths", rsuffix="_pop")
     data[DRAW_COLUMNS] = data[DRAW_COLUMNS].divide(data.value, axis=0)
     return data.drop(["value"], axis="columns")
 
 
 def get_excess_mortality_rate(
-    entity: Cause, location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Cause,
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     csmr = get_data(
-        entity, "cause_specific_mortality_rate", location_id, get_all_years=get_all_years, year_id=year_id
+        entity,
+        "cause_specific_mortality_rate",
+        location_id,
+        get_all_years=get_all_years,
+        year_id=year_id,
     )
-    prevalence = get_data(entity, "prevalence", location_id, get_all_years=get_all_years, year_id=year_id)
+    prevalence = get_data(
+        entity, "prevalence", location_id, get_all_years=get_all_years, year_id=year_id
+    )
     data = (csmr / prevalence).fillna(0)
     data = data.replace([np.inf, -np.inf], 0)
     return data
 
 
 def get_deaths(
-    entity: Cause, location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Cause,
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
-        entity, "deaths", location_id, validate=True, get_all_years=get_all_years, year_id=year_id
+        entity,
+        "deaths",
+        location_id,
+        validate=True,
+        get_all_years=get_all_years,
+        year_id=year_id,
     )
     data = utilities.filter_data_by_restrictions(
         data, entity, "yll", utility_data.get_age_group_ids()
@@ -294,7 +370,12 @@ def get_exposure(
     year_id: int = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
-        entity, "exposure", location_id, validate=True, get_all_years=get_all_years, year_id=year_id
+        entity,
+        "exposure",
+        location_id,
+        validate=True,
+        get_all_years=get_all_years,
+        year_id=year_id,
     )
     data = data.drop("modelable_entity_id", "columns")
 
@@ -353,7 +434,12 @@ def get_exposure_standard_deviation(
     data = data.drop("modelable_entity_id", "columns")
 
     exposure = extract.extract_data(
-        entity, "exposure", location_id, validate=True, get_all_years=get_all_years, year_id=year_id
+        entity,
+        "exposure",
+        location_id,
+        validate=True,
+        get_all_years=get_all_years,
+        year_id=year_id,
     )
     valid_age_groups = utilities.get_exposure_and_restriction_ages(exposure, entity)
     data = data[data.age_group_id.isin(valid_age_groups)]
@@ -379,7 +465,12 @@ def get_exposure_distribution_weights(
     )
 
     exposure = extract.extract_data(
-        entity, "exposure", location_id, validate=True, get_all_years=get_all_years, year_id=year_id
+        entity,
+        "exposure",
+        location_id,
+        validate=True,
+        get_all_years=get_all_years,
+        year_id=year_id,
     )
     valid_ages = utilities.get_exposure_and_restriction_ages(exposure, entity)
 
@@ -431,10 +522,18 @@ def filter_relative_risk_to_cause_restrictions(data: pd.DataFrame) -> pd.DataFra
 
 
 def get_relative_risk(
-    entity: RiskFactor, location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: RiskFactor,
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
-        entity, "relative_risk", location_id, validate=True, get_all_years=get_all_years, year_id=year_id
+        entity,
+        "relative_risk",
+        location_id,
+        validate=True,
+        get_all_years=get_all_years,
+        year_id=year_id,
     )
 
     # FIXME: we don't currently support yll-only causes so I'm dropping them because the data in some cases is
@@ -480,7 +579,10 @@ def filter_by_relative_risk(df: pd.DataFrame, relative_risk: pd.DataFrame) -> pd
 
 
 def get_population_attributable_fraction(
-    entity: Union[RiskFactor, Etiology], location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Union[RiskFactor, Etiology],
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     causes_map = {c.gbd_id: c for c in causes}
     if entity.kind == "risk_factor":
@@ -493,7 +595,12 @@ def get_population_attributable_fraction(
             year_id=year_id,
         )
         relative_risk = extract.extract_data(
-            entity, "relative_risk", location_id, validate=True, get_all_years=get_all_years, year_id=year_id
+            entity,
+            "relative_risk",
+            location_id,
+            validate=True,
+            get_all_years=get_all_years,
+            year_id=year_id,
         )
 
         # FIXME: we don't currently support yll-only causes so I'm dropping them because the data in some cases is
@@ -558,10 +665,18 @@ def get_population_attributable_fraction(
 
 
 def get_estimate(
-    entity: Covariate, location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Covariate,
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
-        entity, "estimate", location_id, validate=True, get_all_years=get_all_years, year_id=year_id
+        entity,
+        "estimate",
+        location_id,
+        validate=True,
+        get_all_years=get_all_years,
+        year_id=year_id,
     )
 
     key_columns = ["location_id", "year_id"]
@@ -584,10 +699,18 @@ def get_utilization_rate(entity: HealthcareEntity, location_id: List[int]) -> pd
 
 
 def get_structure(
-    entity: Population, location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Population,
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
-        entity, "structure", location_id, validate=True, get_all_years=get_all_years, year_id=year_id
+        entity,
+        "structure",
+        location_id,
+        validate=True,
+        get_all_years=get_all_years,
+        year_id=year_id,
     )
     data = data.drop("run_id", axis="columns").rename(columns={"population": "value"})
     data = utilities.normalize(data)
@@ -595,7 +718,10 @@ def get_structure(
 
 
 def get_theoretical_minimum_risk_life_expectancy(
-    entity: Population, location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Population,
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
@@ -611,19 +737,25 @@ def get_theoretical_minimum_risk_life_expectancy(
 
 
 def get_age_bins(
-    entity: Population, location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Population,
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     age_bins = utility_data.get_age_bins()[["age_group_name", "age_start", "age_end"]]
     return age_bins
 
 
 def get_demographic_dimensions(
-    entity: Population, location_id: List[int], get_all_years: bool = False, year_id: int = None,
+    entity: Population,
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     demographic_dimensions = utility_data.get_demographic_dimensions(
         location_id, get_all_years, year_id=year_id
     )
-    #import pdb; pdb.set_trace()
+    # import pdb; pdb.set_trace()
     demographic_dimensions = utilities.normalize(demographic_dimensions)
     return demographic_dimensions
 
@@ -631,7 +763,11 @@ def get_demographic_dimensions(
 def check_year_arguments(get_all_years: bool, year_id: int) -> None:
     if year_id:
         allowed_years = utility_data.get_estimation_years()
-        if get_all_years: # if we have a year ID and get_all_years is True
-            raise ValueError("You cannot provide a year ID and set get_all_years to True in your get_data call.")
+        if get_all_years:  # if we have a year ID and get_all_years is True
+            raise ValueError(
+                "You cannot provide a year ID and set get_all_years to True in your get_data call."
+            )
         if not year_id in allowed_years:
-            raise ValueError(f"year_id must be one of {allowed_years}. You provided {year_id}.")
+            raise ValueError(
+                f"year_id must be one of {allowed_years}. You provided {year_id}."
+            )

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -1,5 +1,5 @@
 from itertools import product
-from typing import List, Union
+from typing import List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -36,7 +36,7 @@ def get_data(
     measure: str,
     location: Union[str, int, List[Union[str, int]]],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ):
     measure_handlers = {
         # Cause-like measures
@@ -122,7 +122,7 @@ def get_raw_incidence_rate(
     entity: Union[Cause, Sequela],
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
@@ -150,7 +150,7 @@ def get_incidence_rate(
     entity: Union[Cause, Sequela],
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = get_data(
         entity,
@@ -171,7 +171,7 @@ def get_prevalence(
     entity: Union[Cause, Sequela],
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
@@ -199,7 +199,7 @@ def get_birth_prevalence(
     entity: Union[Cause, Sequela],
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
@@ -218,7 +218,7 @@ def get_disability_weight(
     entity: Union[Cause, Sequela],
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     if entity.kind == "cause":
         data = utility_data.get_demographic_dimensions(
@@ -283,7 +283,7 @@ def get_remission_rate(
     entity: Cause,
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
@@ -305,7 +305,7 @@ def get_cause_specific_mortality_rate(
     entity: Cause,
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     deaths = get_data(
         entity, "deaths", location_id, get_all_years=get_all_years, year_id=year_id
@@ -322,7 +322,7 @@ def get_excess_mortality_rate(
     entity: Cause,
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     csmr = get_data(
         entity,
@@ -343,7 +343,7 @@ def get_deaths(
     entity: Cause,
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
@@ -365,7 +365,7 @@ def get_exposure(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
@@ -419,7 +419,7 @@ def get_exposure_standard_deviation(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
@@ -451,7 +451,7 @@ def get_exposure_distribution_weights(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
@@ -523,7 +523,7 @@ def get_relative_risk(
     entity: RiskFactor,
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
@@ -580,7 +580,7 @@ def get_population_attributable_fraction(
     entity: Union[RiskFactor, Etiology],
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     causes_map = {c.gbd_id: c for c in causes}
     if entity.kind == "risk_factor":
@@ -666,7 +666,7 @@ def get_estimate(
     entity: Covariate,
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
@@ -700,7 +700,7 @@ def get_structure(
     entity: Population,
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
@@ -719,7 +719,7 @@ def get_theoretical_minimum_risk_life_expectancy(
     entity: Population,
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
@@ -738,7 +738,7 @@ def get_age_bins(
     entity: Population,
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     age_bins = utility_data.get_age_bins()[["age_group_name", "age_start", "age_end"]]
     return age_bins
@@ -748,7 +748,7 @@ def get_demographic_dimensions(
     entity: Population,
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     demographic_dimensions = utility_data.get_demographic_dimensions(
         location_id, get_all_years, year_id=year_id

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -35,8 +35,7 @@ def get_data(
     entity: ModelableEntity,
     measure: str,
     location: Union[str, int, List[Union[str, int]]],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ):
     measure_handlers = {
         # Cause-like measures
@@ -99,9 +98,8 @@ def get_data(
         location_id = [
             utility_data.get_location_id(location) if isinstance(location, str) else location
         ]
-    # check year related arguments
-    check_year_arguments(get_all_years, year_id)
-    data = handler(entity, location_id, get_all_years, year_id)
+
+    data = handler(entity, location_id, year_id)
 
     if measure in [
         "structure",
@@ -121,15 +119,13 @@ def get_data(
 def get_raw_incidence_rate(
     entity: Union[Cause, Sequela],
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "incidence_rate",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     if entity.kind == "cause":
@@ -149,19 +145,15 @@ def get_raw_incidence_rate(
 def get_incidence_rate(
     entity: Union[Cause, Sequela],
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = get_data(
         entity,
         "raw_incidence_rate",
         location_id,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
-    prevalence = get_data(
-        entity, "prevalence", location_id, get_all_years=get_all_years, year_id=year_id
-    )
+    prevalence = get_data(entity, "prevalence", location_id, year_id=year_id)
     # Convert from "True incidence" to the incidence rate among susceptibles
     data /= 1 - prevalence
     return data.fillna(0)
@@ -170,15 +162,13 @@ def get_incidence_rate(
 def get_prevalence(
     entity: Union[Cause, Sequela],
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "prevalence",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     if entity.kind == "cause":
@@ -198,15 +188,13 @@ def get_prevalence(
 def get_birth_prevalence(
     entity: Union[Cause, Sequela],
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "birth_prevalence",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     data = data.filter(["year_id", "sex_id", "location_id"] + DRAW_COLUMNS)
@@ -217,12 +205,11 @@ def get_birth_prevalence(
 def get_disability_weight(
     entity: Union[Cause, Sequela],
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     if entity.kind == "cause":
         data = utility_data.get_demographic_dimensions(
-            location_id, get_all_years, draws=True, value=0.0, year_id=year_id
+            location_id, draws=True, value=0.0, year_id=year_id
         )
         data = data.set_index(
             utilities.get_ordered_index_cols(data.columns.difference(DRAW_COLUMNS))
@@ -234,7 +221,6 @@ def get_disability_weight(
                         sequela,
                         "prevalence",
                         location_id,
-                        get_all_years=get_all_years,
                         year_id=year_id,
                     )
                 except DataDoesNotExistError:
@@ -244,12 +230,11 @@ def get_disability_weight(
                     sequela,
                     "disability_weight",
                     location_id,
-                    get_all_years=get_all_years,
                     year_id=year_id,
                 )
                 data += prevalence * disability
         cause_prevalence = get_data(
-            entity, "prevalence", location_id, get_all_years=get_all_years, year_id=year_id
+            entity, "prevalence", location_id, year_id=year_id
         )
         data = (data / cause_prevalence).fillna(0).reset_index()
     else:  # entity.kind == 'sequela'
@@ -259,7 +244,6 @@ def get_disability_weight(
                 "disability_weight",
                 location_id,
                 validate=True,
-                get_all_years=get_all_years,
                 year_id=year_id,
             )
             data = utilities.normalize(data)
@@ -274,7 +258,7 @@ def get_disability_weight(
                 f"{entity.name.capitalize()} has no disability weight data. All values will be 0."
             )
             data = utility_data.get_demographic_dimensions(
-                location_id, get_all_years, draws=True, value=0.0
+                location_id, draws=True, value=0.0, year_id=year_id
             )
     return data
 
@@ -282,15 +266,13 @@ def get_disability_weight(
 def get_remission_rate(
     entity: Cause,
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "remission_rate",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     data = utilities.filter_data_by_restrictions(
@@ -304,15 +286,11 @@ def get_remission_rate(
 def get_cause_specific_mortality_rate(
     entity: Cause,
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
-    deaths = get_data(
-        entity, "deaths", location_id, get_all_years=get_all_years, year_id=year_id
-    )  # population isn't by draws
-    pop = get_data(
-        Population(), "structure", location_id, get_all_years=get_all_years, year_id=year_id
-    )
+    deaths = get_data(entity, "deaths", location_id, year_id=year_id)
+    # population isn't by draws
+    pop = get_data(Population(), "structure", location_id, year_id=year_id)
     data = deaths.join(pop, lsuffix="_deaths", rsuffix="_pop")
     data[DRAW_COLUMNS] = data[DRAW_COLUMNS].divide(data.value, axis=0)
     return data.drop(["value"], axis="columns")
@@ -321,19 +299,15 @@ def get_cause_specific_mortality_rate(
 def get_excess_mortality_rate(
     entity: Cause,
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     csmr = get_data(
         entity,
         "cause_specific_mortality_rate",
         location_id,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
-    prevalence = get_data(
-        entity, "prevalence", location_id, get_all_years=get_all_years, year_id=year_id
-    )
+    prevalence = get_data(entity, "prevalence", location_id, year_id=year_id)
     data = (csmr / prevalence).fillna(0)
     data = data.replace([np.inf, -np.inf], 0)
     return data
@@ -342,15 +316,13 @@ def get_excess_mortality_rate(
 def get_deaths(
     entity: Cause,
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "deaths",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     data = utilities.filter_data_by_restrictions(
@@ -364,15 +336,13 @@ def get_deaths(
 def get_exposure(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "exposure",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     data = data.drop("modelable_entity_id", "columns")
@@ -418,15 +388,13 @@ def get_exposure(
 def get_exposure_standard_deviation(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "exposure_standard_deviation",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     data = data.drop("modelable_entity_id", "columns")
@@ -436,7 +404,6 @@ def get_exposure_standard_deviation(
         "exposure",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     valid_age_groups = utilities.get_exposure_and_restriction_ages(exposure, entity)
@@ -450,15 +417,13 @@ def get_exposure_standard_deviation(
 def get_exposure_distribution_weights(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "exposure_distribution_weights",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
 
@@ -467,7 +432,6 @@ def get_exposure_distribution_weights(
         "exposure",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     valid_ages = utilities.get_exposure_and_restriction_ages(exposure, entity)
@@ -480,7 +444,7 @@ def get_exposure_distribution_weights(
         df.append(copied)
     data = pd.concat(df)
     data = utilities.normalize(data, fill_value=0, cols_to_fill=DISTRIBUTION_COLUMNS)
-    if not get_all_years:
+    if year_id != 'all':
         if year_id:
             data = data.query("year_id==@year_id")
         else:
@@ -522,15 +486,13 @@ def filter_relative_risk_to_cause_restrictions(data: pd.DataFrame) -> pd.DataFra
 def get_relative_risk(
     entity: RiskFactor,
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "relative_risk",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
 
@@ -579,8 +541,7 @@ def filter_by_relative_risk(df: pd.DataFrame, relative_risk: pd.DataFrame) -> pd
 def get_population_attributable_fraction(
     entity: Union[RiskFactor, Etiology],
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     causes_map = {c.gbd_id: c for c in causes}
     if entity.kind == "risk_factor":
@@ -589,7 +550,6 @@ def get_population_attributable_fraction(
             "population_attributable_fraction",
             location_id,
             validate=True,
-            get_all_years=get_all_years,
             year_id=year_id,
         )
         relative_risk = extract.extract_data(
@@ -597,7 +557,6 @@ def get_population_attributable_fraction(
             "relative_risk",
             location_id,
             validate=True,
-            get_all_years=get_all_years,
             year_id=year_id,
         )
 
@@ -631,7 +590,6 @@ def get_population_attributable_fraction(
             "etiology_population_attributable_fraction",
             location_id,
             validate=True,
-            get_all_years=get_all_years,
             year_id=year_id,
         )
         cause = [c for c in causes if entity in c.etiologies][0]
@@ -665,15 +623,13 @@ def get_population_attributable_fraction(
 def get_estimate(
     entity: Covariate,
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "estimate",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
 
@@ -699,15 +655,13 @@ def get_utilization_rate(entity: HealthcareEntity, location_id: List[int]) -> pd
 def get_structure(
     entity: Population,
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "structure",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     data = data.drop("run_id", axis="columns").rename(columns={"population": "value"})
@@ -718,15 +672,13 @@ def get_structure(
 def get_theoretical_minimum_risk_life_expectancy(
     entity: Population,
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "theoretical_minimum_risk_life_expectancy",
         location_id,
         validate=True,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     data = data.rename(columns={"age": "age_start", "life_expectancy": "value"})
@@ -737,8 +689,7 @@ def get_theoretical_minimum_risk_life_expectancy(
 def get_age_bins(
     entity: Population,
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     age_bins = utility_data.get_age_bins()[["age_group_name", "age_start", "age_end"]]
     return age_bins
@@ -747,25 +698,11 @@ def get_age_bins(
 def get_demographic_dimensions(
     entity: Population,
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     demographic_dimensions = utility_data.get_demographic_dimensions(
-        location_id, get_all_years, year_id=year_id
+        location_id, year_id=year_id
     )
     demographic_dimensions = utilities.normalize(demographic_dimensions)
     return demographic_dimensions
 
-
-def check_year_arguments(get_all_years: bool, year_id: Optional[int]) -> None:
-    if year_id:
-        if get_all_years:  # if we have a year ID and get_all_years is True
-            raise ValueError(
-                "You cannot provide a year ID and set get_all_years to True in your get_data call."
-            )
-        # check year id is an estimation year
-        allowed_years = utility_data.get_estimation_years()
-        if not year_id in allowed_years:
-            raise ValueError(
-                f"year_id must be one of {allowed_years}. You provided {year_id}."
-            )

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -621,8 +621,9 @@ def get_demographic_dimensions(
     entity: Population, location_id: List[int], get_all_years: bool = False, year_id: int = None,
 ) -> pd.DataFrame:
     demographic_dimensions = utility_data.get_demographic_dimensions(
-        location_id, get_all_years
+        location_id, get_all_years, year_id=year_id
     )
+    #import pdb; pdb.set_trace()
     demographic_dimensions = utilities.normalize(demographic_dimensions)
     return demographic_dimensions
 

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -35,7 +35,7 @@ def get_data(
     entity: ModelableEntity,
     measure: str,
     location: Union[str, int, List[Union[str, int]]],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ):
     measure_handlers = {
         # Cause-like measures
@@ -99,7 +99,7 @@ def get_data(
             utility_data.get_location_id(location) if isinstance(location, str) else location
         ]
 
-    data = handler(entity, location_id, year_id)
+    data = handler(entity, location_id, years)
 
     if measure in [
         "structure",
@@ -119,14 +119,14 @@ def get_data(
 def get_raw_incidence_rate(
     entity: Union[Cause, Sequela],
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "incidence_rate",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
     if entity.kind == "cause":
         restrictions_entity = entity
@@ -145,15 +145,15 @@ def get_raw_incidence_rate(
 def get_incidence_rate(
     entity: Union[Cause, Sequela],
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = get_data(
         entity,
         "raw_incidence_rate",
         location_id,
-        year_id=year_id,
+        years=years,
     )
-    prevalence = get_data(entity, "prevalence", location_id, year_id=year_id)
+    prevalence = get_data(entity, "prevalence", location_id, years=years)
     # Convert from "True incidence" to the incidence rate among susceptibles
     data /= 1 - prevalence
     return data.fillna(0)
@@ -162,14 +162,14 @@ def get_incidence_rate(
 def get_prevalence(
     entity: Union[Cause, Sequela],
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "prevalence",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
     if entity.kind == "cause":
         restrictions_entity = entity
@@ -188,16 +188,16 @@ def get_prevalence(
 def get_birth_prevalence(
     entity: Union[Cause, Sequela],
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "birth_prevalence",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
-    data = data.filter(["year_id", "sex_id", "location_id"] + DRAW_COLUMNS)
+    data = data.filter(["years", "sex_id", "location_id"] + DRAW_COLUMNS)
     data = utilities.normalize(data, fill_value=0)
     return data
 
@@ -205,11 +205,11 @@ def get_birth_prevalence(
 def get_disability_weight(
     entity: Union[Cause, Sequela],
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     if entity.kind == "cause":
         data = utility_data.get_demographic_dimensions(
-            location_id, draws=True, value=0.0, year_id=year_id
+            location_id, draws=True, value=0.0, years=years
         )
         data = data.set_index(
             utilities.get_ordered_index_cols(data.columns.difference(DRAW_COLUMNS))
@@ -221,7 +221,7 @@ def get_disability_weight(
                         sequela,
                         "prevalence",
                         location_id,
-                        year_id=year_id,
+                        years=years,
                     )
                 except DataDoesNotExistError:
                     # sequela prevalence does not exist so no point continuing with this sequela
@@ -230,10 +230,10 @@ def get_disability_weight(
                     sequela,
                     "disability_weight",
                     location_id,
-                    year_id=year_id,
+                    years=years,
                 )
                 data += prevalence * disability
-        cause_prevalence = get_data(entity, "prevalence", location_id, year_id=year_id)
+        cause_prevalence = get_data(entity, "prevalence", location_id, years=years)
         data = (data / cause_prevalence).fillna(0).reset_index()
     else:  # entity.kind == 'sequela'
         try:
@@ -242,7 +242,7 @@ def get_disability_weight(
                 "disability_weight",
                 location_id,
                 validate=True,
-                year_id=year_id,
+                years=years,
             )
             data = utilities.normalize(data)
 
@@ -256,7 +256,7 @@ def get_disability_weight(
                 f"{entity.name.capitalize()} has no disability weight data. All values will be 0."
             )
             data = utility_data.get_demographic_dimensions(
-                location_id, draws=True, value=0.0, year_id=year_id
+                location_id, draws=True, value=0.0, years=years
             )
     return data
 
@@ -264,14 +264,14 @@ def get_disability_weight(
 def get_remission_rate(
     entity: Cause,
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "remission_rate",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
     data = utilities.filter_data_by_restrictions(
         data, entity, "yld", utility_data.get_age_group_ids()
@@ -284,11 +284,11 @@ def get_remission_rate(
 def get_cause_specific_mortality_rate(
     entity: Cause,
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
-    deaths = get_data(entity, "deaths", location_id, year_id=year_id)
+    deaths = get_data(entity, "deaths", location_id, years=years)
     # population isn't by draws
-    pop = get_data(Population(), "structure", location_id, year_id=year_id)
+    pop = get_data(Population(), "structure", location_id, years=years)
     data = deaths.join(pop, lsuffix="_deaths", rsuffix="_pop")
     data[DRAW_COLUMNS] = data[DRAW_COLUMNS].divide(data.value, axis=0)
     return data.drop(["value"], axis="columns")
@@ -297,15 +297,15 @@ def get_cause_specific_mortality_rate(
 def get_excess_mortality_rate(
     entity: Cause,
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     csmr = get_data(
         entity,
         "cause_specific_mortality_rate",
         location_id,
-        year_id=year_id,
+        years=years,
     )
-    prevalence = get_data(entity, "prevalence", location_id, year_id=year_id)
+    prevalence = get_data(entity, "prevalence", location_id, years=years)
     data = (csmr / prevalence).fillna(0)
     data = data.replace([np.inf, -np.inf], 0)
     return data
@@ -314,14 +314,14 @@ def get_excess_mortality_rate(
 def get_deaths(
     entity: Cause,
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "deaths",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
     data = utilities.filter_data_by_restrictions(
         data, entity, "yll", utility_data.get_age_group_ids()
@@ -334,14 +334,14 @@ def get_deaths(
 def get_exposure(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "exposure",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
     data = data.drop("modelable_entity_id", "columns")
 
@@ -386,14 +386,14 @@ def get_exposure(
 def get_exposure_standard_deviation(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "exposure_standard_deviation",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
     data = data.drop("modelable_entity_id", "columns")
 
@@ -402,7 +402,7 @@ def get_exposure_standard_deviation(
         "exposure",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
     valid_age_groups = utilities.get_exposure_and_restriction_ages(exposure, entity)
     data = data[data.age_group_id.isin(valid_age_groups)]
@@ -415,14 +415,14 @@ def get_exposure_standard_deviation(
 def get_exposure_distribution_weights(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "exposure_distribution_weights",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
 
     exposure = extract.extract_data(
@@ -430,7 +430,7 @@ def get_exposure_distribution_weights(
         "exposure",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
     valid_ages = utilities.get_exposure_and_restriction_ages(exposure, entity)
 
@@ -442,12 +442,12 @@ def get_exposure_distribution_weights(
         df.append(copied)
     data = pd.concat(df)
     data = utilities.normalize(data, fill_value=0, cols_to_fill=DISTRIBUTION_COLUMNS)
-    if year_id != "all":
-        if year_id:
-            data = data.query("year_id==@year_id")
+    if years != "all":
+        if years:
+            data = data.query(f"years=={years}")
         else:
             most_recent_year = gbd.get_most_recent_year()
-            data = data.query("year_id==@most_recent_year")
+            data = data.query(f"years=={most_recent_year}")
     data = data.filter(DEMOGRAPHIC_COLUMNS + DISTRIBUTION_COLUMNS)
     data = utilities.wide_to_long(data, DISTRIBUTION_COLUMNS, var_name="parameter")
     return data
@@ -484,14 +484,14 @@ def filter_relative_risk_to_cause_restrictions(data: pd.DataFrame) -> pd.DataFra
 def get_relative_risk(
     entity: RiskFactor,
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "relative_risk",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
 
     # FIXME: we don't currently support yll-only causes so I'm dropping them because the data in some cases is
@@ -539,7 +539,7 @@ def filter_by_relative_risk(df: pd.DataFrame, relative_risk: pd.DataFrame) -> pd
 def get_population_attributable_fraction(
     entity: Union[RiskFactor, Etiology],
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     causes_map = {c.gbd_id: c for c in causes}
     if entity.kind == "risk_factor":
@@ -548,14 +548,14 @@ def get_population_attributable_fraction(
             "population_attributable_fraction",
             location_id,
             validate=True,
-            year_id=year_id,
+            years=years,
         )
         relative_risk = extract.extract_data(
             entity,
             "relative_risk",
             location_id,
             validate=True,
-            year_id=year_id,
+            years=years,
         )
 
         # FIXME: we don't currently support yll-only causes so I'm dropping them because the data in some cases is
@@ -588,7 +588,7 @@ def get_population_attributable_fraction(
             "etiology_population_attributable_fraction",
             location_id,
             validate=True,
-            year_id=year_id,
+            years=years,
         )
         cause = [c for c in causes if entity in c.etiologies][0]
         data = utilities.filter_data_by_restrictions(
@@ -621,14 +621,14 @@ def get_population_attributable_fraction(
 def get_estimate(
     entity: Covariate,
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "estimate",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
 
     key_columns = ["location_id", "year_id"]
@@ -653,14 +653,14 @@ def get_utilization_rate(entity: HealthcareEntity, location_id: List[int]) -> pd
 def get_structure(
     entity: Population,
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "structure",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
     data = data.drop("run_id", axis="columns").rename(columns={"population": "value"})
     data = utilities.normalize(data)
@@ -670,14 +670,14 @@ def get_structure(
 def get_theoretical_minimum_risk_life_expectancy(
     entity: Population,
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = extract.extract_data(
         entity,
         "theoretical_minimum_risk_life_expectancy",
         location_id,
         validate=True,
-        year_id=year_id,
+        years=years,
     )
     data = data.rename(columns={"age": "age_start", "life_expectancy": "value"})
     data["age_end"] = data.age_start.shift(-1).fillna(125.0)
@@ -687,7 +687,7 @@ def get_theoretical_minimum_risk_life_expectancy(
 def get_age_bins(
     entity: Population,
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     age_bins = utility_data.get_age_bins()[["age_group_name", "age_start", "age_end"]]
     return age_bins
@@ -696,10 +696,10 @@ def get_age_bins(
 def get_demographic_dimensions(
     entity: Population,
     location_id: List[int],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     demographic_dimensions = utility_data.get_demographic_dimensions(
-        location_id, year_id=year_id
+        location_id, years=years
     )
     demographic_dimensions = utilities.normalize(demographic_dimensions)
     return demographic_dimensions

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -222,10 +222,8 @@ def get_disability_weight(
 ) -> pd.DataFrame:
     if entity.kind == "cause":
         data = utility_data.get_demographic_dimensions(
-            location_id, get_all_years, draws=True, value=0.0
+            location_id, get_all_years, draws=True, value=0.0, year_id=year_id
         )
-        if year_id:
-            data["year_id"] = year_id
         data = data.set_index(
             utilities.get_ordered_index_cols(data.columns.difference(DRAW_COLUMNS))
         )
@@ -755,18 +753,18 @@ def get_demographic_dimensions(
     demographic_dimensions = utility_data.get_demographic_dimensions(
         location_id, get_all_years, year_id=year_id
     )
-    # import pdb; pdb.set_trace()
     demographic_dimensions = utilities.normalize(demographic_dimensions)
     return demographic_dimensions
 
 
 def check_year_arguments(get_all_years: bool, year_id: int) -> None:
     if year_id:
-        allowed_years = utility_data.get_estimation_years()
         if get_all_years:  # if we have a year ID and get_all_years is True
             raise ValueError(
                 "You cannot provide a year ID and set get_all_years to True in your get_data call."
             )
+        # check year id is an estimation year
+        allowed_years = utility_data.get_estimation_years()
         if not year_id in allowed_years:
             raise ValueError(
                 f"year_id must be one of {allowed_years}. You provided {year_id}."

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -698,8 +698,6 @@ def get_demographic_dimensions(
     location_id: List[int],
     years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
-    demographic_dimensions = utility_data.get_demographic_dimensions(
-        location_id, years=years
-    )
+    demographic_dimensions = utility_data.get_demographic_dimensions(location_id, years=years)
     demographic_dimensions = utilities.normalize(demographic_dimensions)
     return demographic_dimensions

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -629,6 +629,9 @@ def get_demographic_dimensions(
 
 
 def check_year_arguments(get_all_years: bool, year_id: int) -> None:
-    # check that get_all_years and year_id are compatible
-    # check that year_id is in estimation years
-    pass
+    if year_id:
+        allowed_years = utility_data.get_estimation_years()
+        if get_all_years: # if we have a year ID and get_all_years is True
+            raise ValueError("You cannot provide a year ID and set get_all_years to True in your get_data call.")
+        if not year_id in allowed_years:
+            raise ValueError(f"year_id must be one of {allowed_years}. You provided {year_id}.")

--- a/src/vivarium_inputs/core.py
+++ b/src/vivarium_inputs/core.py
@@ -757,7 +757,7 @@ def get_demographic_dimensions(
     return demographic_dimensions
 
 
-def check_year_arguments(get_all_years: bool, year_id: int) -> None:
+def check_year_arguments(get_all_years: bool, year_id: Optional[int]) -> None:
     if year_id:
         if get_all_years:  # if we have a year ID and get_all_years is True
             raise ValueError(

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -29,7 +29,7 @@ def extract_data(
     measure: str,
     location_id: List[int],
     validate: bool = True,
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> Union[pd.Series, pd.DataFrame]:
     """Check metadata for the requested entity-measure pair. Pull raw data from
     GBD. The only filtering that occurs is by applicable measure id, metric id,
@@ -50,8 +50,8 @@ def extract_data(
         should be extracted and whether raw validation should be performed.
         Should only be set to False if data is being extracted for
         investigation. Never extract data for a simulation without validation.
-    year_id
-        Year for which to extract data. If None, get most recent year. If 'all',
+    years
+        Years for which to extract data. If None, get most recent year. If 'all',
         get all available data. Defaults to None.
 
     Returns
@@ -104,16 +104,16 @@ def extract_data(
     validation.check_metadata(entity, measure)
 
     # update year_id value for gbd calls
-    if year_id == None:  # default to most recent year
+    if years == None:  # default to most recent year
         year_id = gbd.get_most_recent_year()
-    elif year_id == "all":
+    elif years == "all":
         year_id = None
-    # check that we're using a valid year
-    if year_id:
+    # check that we're using a valid year if years is int
+    if years:
         estimation_years = gbd.get_estimation_years()
-        if year_id not in estimation_years:
+        if years not in estimation_years:
             raise ValueError(
-                f"year_id must be in {estimation_years}. You provided {year_id}."
+                f"years must be in {estimation_years}. You provided {year_id}."
             )
 
     try:

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -108,13 +108,13 @@ def extract_data(
         year_id = gbd.get_most_recent_year()
     elif years == "all":
         year_id = None
-    # check that we're using a valid year if years is int
-    if years:
+    else:
         estimation_years = gbd.get_estimation_years()
         if years not in estimation_years:
             raise ValueError(
-                f"years must be in {estimation_years}. You provided {year_id}."
+                f"years must be in {estimation_years}. You provided {years}."
             )
+        year_id = years
 
     try:
         main_extractor, additional_extractors = extractors[measure]

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -138,7 +138,7 @@ def extract_data(
 
     if validate:
         additional_data = {
-            name: extractor(entity, location_id, get_all_years=get_all_years)
+            name: extractor(entity, location_id, get_all_years=get_all_years, year_id=year_id)
             for name, extractor in additional_extractors.items()
         }
         if not get_all_years:
@@ -224,11 +224,10 @@ def extract_disability_weight(
         loc_data["location_id"] = loc_id
         data.append(loc_data)
     data = pd.concat(data)
-    if not get_all_years:
-        if year_id:
-            data["year_id"] = year_id
-        else:
-            data["year_id"] = gbd.get_most_recent_year()
+    if year_id:
+        data["year_id"] = year_id
+    else:
+        data["year_id"] = gbd.get_most_recent_year()
     return data
 
 

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -203,7 +203,10 @@ def extract_birth_prevalence(
 
 
 def extract_remission_rate(
-    entity: Cause, location_id: List[int], get_all_years: bool = False, year_id: int = None
+    entity: Cause,
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = gbd.get_modelable_entity_draws(
         entity.me_id, location_id, get_all_years=get_all_years, year_id=year_id
@@ -213,7 +216,10 @@ def extract_remission_rate(
 
 
 def extract_disability_weight(
-    entity: Sequela, location_id: List[int], get_all_years: bool = False, year_id: int = None
+    entity: Sequela,
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     disability_weights = gbd.get_auxiliary_data(
         "disability_weight",
@@ -241,7 +247,10 @@ def extract_disability_weight(
 
 
 def extract_deaths(
-    entity: Cause, location_id: List[int], get_all_years: bool = False, year_id: int = None
+    entity: Cause,
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = gbd.get_codcorrect_draws(
         entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id
@@ -316,7 +325,10 @@ def extract_exposure_distribution_weights(
 
 
 def extract_relative_risk(
-    entity: RiskFactor, location_id: int, get_all_years: bool = False, year_id: int = None
+    entity: RiskFactor,
+    location_id: int,
+    get_all_years: bool = False,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = gbd.get_relative_risk(
         entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id
@@ -355,14 +367,20 @@ def extract_population_attributable_fraction(
 
 
 def extract_mediation_factors(
-    entity: RiskFactor, location_id: int, get_all_years: bool = False, year_id: int = None
+    entity: RiskFactor,
+    location_id: int,
+    get_all_years: bool = False,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = gbd.get_auxiliary_data("mediation_factor", entity.kind, entity.name, location_id)
     return data
 
 
 def extract_estimate(
-    entity: Covariate, location_id: int, get_all_years: bool = False, year_id: int = None
+    entity: Covariate,
+    location_id: int,
+    get_all_years: bool = False,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = gbd.get_covariate_estimate(
         int(entity.gbd_id), location_id, get_all_years=get_all_years, year_id=year_id
@@ -376,14 +394,20 @@ def extract_utilization_rate(entity: HealthcareEntity, location_id: int) -> pd.D
 
 
 def extract_structure(
-    entity: Population, location_id: int, get_all_years: bool = False, year_id: int = None
+    entity: Population,
+    location_id: int,
+    get_all_years: bool = False,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = gbd.get_population(location_id, get_all_years=get_all_years, year_id=year_id)
     return data
 
 
 def extract_theoretical_minimum_risk_life_expectancy(
-    entity: Population, location_id: int, get_all_years: bool = False, year_id: int = None
+    entity: Population,
+    location_id: int,
+    get_all_years: bool = False,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = gbd.get_theoretical_minimum_risk_life_expectancy()
     return data

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -111,9 +111,7 @@ def extract_data(
     else:
         estimation_years = gbd.get_estimation_years()
         if years not in estimation_years:
-            raise ValueError(
-                f"years must be in {estimation_years}. You provided {years}."
-            )
+            raise ValueError(f"years must be in {estimation_years}. You provided {years}.")
         year_id = years
 
     try:

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -29,8 +29,7 @@ def extract_data(
     measure: str,
     location_id: List[int],
     validate: bool = True,
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> Union[pd.Series, pd.DataFrame]:
     """Check metadata for the requested entity-measure pair. Pull raw data from
     GBD. The only filtering that occurs is by applicable measure id, metric id,
@@ -104,9 +103,15 @@ def extract_data(
 
     validation.check_metadata(entity, measure)
 
+    # update year_id value for gbd calls
+    if year_id == None: # default to most recent year
+        year_id = gbd.get_most_recent_year()
+    elif year_id == 'all':
+        year_id = None
+
     try:
         main_extractor, additional_extractors = extractors[measure]
-        data = main_extractor(entity, location_id, get_all_years, year_id)
+        data = main_extractor(entity, location_id, year_id)
     except (
         ValueError,
         AssertionError,
@@ -138,14 +143,11 @@ def extract_data(
 
     if validate:
         additional_data = {
-            name: extractor(entity, location_id, get_all_years=get_all_years, year_id=year_id)
+            name: extractor(entity, location_id, year_id)
             for name, extractor in additional_extractors.items()
         }
-        if not get_all_years:
-            if year_id:
-                additional_data["estimation_years"] = [year_id]
-            else:
-                additional_data["estimation_years"] = [gbd.get_most_recent_year()]
+        if year_id: # if not pulling all years
+            additional_data["estimation_years"] = [year_id]
         validation.validate_raw_data(data, entity, measure, location_id, **additional_data)
 
     return data
@@ -154,14 +156,12 @@ def extract_data(
 def extract_prevalence(
     entity: Union[Cause, Sequela],
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = gbd.get_incidence_prevalence(
         entity_id=entity.gbd_id,
         location_id=location_id,
         entity_type=entity.kind,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     data = data[data.measure_id == MEASURES["Prevalence"]]
@@ -171,14 +171,12 @@ def extract_prevalence(
 def extract_incidence_rate(
     entity: Union[Cause, Sequela],
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = gbd.get_incidence_prevalence(
         entity_id=entity.gbd_id,
         location_id=location_id,
         entity_type=entity.kind,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     data = data[data.measure_id == MEASURES["Incidence rate"]]
@@ -188,14 +186,12 @@ def extract_incidence_rate(
 def extract_birth_prevalence(
     entity: Union[Cause, Sequela],
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = gbd.get_birth_prevalence(
         entity_id=entity.gbd_id,
         location_id=location_id,
         entity_type=entity.kind,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     data = data[data.measure_id == MEASURES["Incidence rate"]]
@@ -205,11 +201,10 @@ def extract_birth_prevalence(
 def extract_remission_rate(
     entity: Cause,
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = gbd.get_modelable_entity_draws(
-        entity.me_id, location_id, get_all_years=get_all_years, year_id=year_id
+        entity.me_id, location_id, year_id=year_id
     )
     data = data[data.measure_id == MEASURES["Remission rate"]]
     return data
@@ -218,8 +213,7 @@ def extract_remission_rate(
 def extract_disability_weight(
     entity: Sequela,
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     disability_weights = gbd.get_auxiliary_data(
         "disability_weight",
@@ -239,21 +233,18 @@ def extract_disability_weight(
         loc_data["location_id"] = loc_id
         data.append(loc_data)
     data = pd.concat(data)
-    if year_id:
+    if year_id: # if not pulling all years
         data["year_id"] = year_id
-    else:
-        data["year_id"] = gbd.get_most_recent_year()
     return data
 
 
 def extract_deaths(
     entity: Cause,
     location_id: List[int],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = gbd.get_codcorrect_draws(
-        entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id
+        entity.gbd_id, location_id, year_id=year_id
     )
     data = data[data.measure_id == MEASURES["Deaths"]]
     return data
@@ -262,12 +253,11 @@ def extract_deaths(
 def extract_exposure(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: int,
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     if entity.kind == "risk_factor":
         data = gbd.get_exposure(
-            entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id
+            entity.gbd_id, location_id, year_id=year_id
         )
         if entity.gbd_id == 341:
             data = process_kidney_dysfunction_exposure(data)
@@ -294,16 +284,15 @@ def extract_exposure(
 def extract_exposure_standard_deviation(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: int,
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     if entity.kind == "risk_factor" and entity.name in OTHER_MEID:
         data = gbd.get_modelable_entity_draws(
-            OTHER_MEID[entity.name], location_id, get_all_years=get_all_years, year_id=year_id
+            OTHER_MEID[entity.name], location_id, year_id=year_id
         )
     elif entity.kind == "risk_factor":
         data = gbd.get_exposure_standard_deviation(
-            entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id
+            entity.gbd_id, location_id, year_id=year_id
         )
     else:  # alternative_risk_factor
         data = gbd.get_auxiliary_data(
@@ -315,8 +304,7 @@ def extract_exposure_standard_deviation(
 def extract_exposure_distribution_weights(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: int,
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = gbd.get_auxiliary_data(
         "exposure_distribution_weights", entity.kind, entity.name, location_id
@@ -327,11 +315,10 @@ def extract_exposure_distribution_weights(
 def extract_relative_risk(
     entity: RiskFactor,
     location_id: int,
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = gbd.get_relative_risk(
-        entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id
+        entity.gbd_id, location_id, year_id=year_id
     )
     # TODO: [MIC-4891] Process new relative risk data format properly
     if not data["exposure"].isna().all():
@@ -350,16 +337,15 @@ def extract_relative_risk(
 def extract_population_attributable_fraction(
     entity: Union[RiskFactor, Etiology],
     location_id: int,
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = gbd.get_paf(
-        entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id
+        entity.gbd_id, location_id, year_id=year_id
     )
     data = data[data.metric_id == METRICS["Percent"]]
     data = data[data.measure_id.isin([MEASURES["YLDs"], MEASURES["YLLs"]])]
     data = filter_to_most_detailed_causes(data)
-    # clip PAFs between 0 and 1 (expected from GBD)
+    # clip PAFs between 0 and 1 (data outside these bounds is expected from GBD)
     draw_cols = [col for col in data.columns if col.startswith("draw_")]
     data.loc[:, draw_cols] = data[draw_cols].clip(lower=0)
     data.loc[:, draw_cols] = data[draw_cols].clip(upper=1)
@@ -369,8 +355,7 @@ def extract_population_attributable_fraction(
 def extract_mediation_factors(
     entity: RiskFactor,
     location_id: int,
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = gbd.get_auxiliary_data("mediation_factor", entity.kind, entity.name, location_id)
     return data
@@ -379,11 +364,10 @@ def extract_mediation_factors(
 def extract_estimate(
     entity: Covariate,
     location_id: int,
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = gbd.get_covariate_estimate(
-        int(entity.gbd_id), location_id, get_all_years=get_all_years, year_id=year_id
+        int(entity.gbd_id), location_id, year_id=year_id
     )
     return data
 
@@ -396,18 +380,16 @@ def extract_utilization_rate(entity: HealthcareEntity, location_id: int) -> pd.D
 def extract_structure(
     entity: Population,
     location_id: int,
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
-    data = gbd.get_population(location_id, get_all_years=get_all_years, year_id=year_id)
+    data = gbd.get_population(location_id, year_id=year_id)
     return data
 
 
 def extract_theoretical_minimum_risk_life_expectancy(
     entity: Population,
     location_id: int,
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     data = gbd.get_theoretical_minimum_risk_life_expectancy()
     return data

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -152,7 +152,10 @@ def extract_data(
 
 
 def extract_prevalence(
-    entity: Union[Cause, Sequela], location_id: List[int], get_all_years: bool = False, year_id: int = None
+    entity: Union[Cause, Sequela],
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     data = gbd.get_incidence_prevalence(
         entity_id=entity.gbd_id,
@@ -166,7 +169,10 @@ def extract_prevalence(
 
 
 def extract_incidence_rate(
-    entity: Union[Cause, Sequela], location_id: List[int], get_all_years: bool = False, year_id: int = None
+    entity: Union[Cause, Sequela],
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     data = gbd.get_incidence_prevalence(
         entity_id=entity.gbd_id,
@@ -180,7 +186,10 @@ def extract_incidence_rate(
 
 
 def extract_birth_prevalence(
-    entity: Union[Cause, Sequela], location_id: List[int], get_all_years: bool = False, year_id: int = None
+    entity: Union[Cause, Sequela],
+    location_id: List[int],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     data = gbd.get_birth_prevalence(
         entity_id=entity.gbd_id,
@@ -234,7 +243,9 @@ def extract_disability_weight(
 def extract_deaths(
     entity: Cause, location_id: List[int], get_all_years: bool = False, year_id: int = None
 ) -> pd.DataFrame:
-    data = gbd.get_codcorrect_draws(entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id)
+    data = gbd.get_codcorrect_draws(
+        entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id
+    )
     data = data[data.measure_id == MEASURES["Deaths"]]
     return data
 
@@ -246,7 +257,9 @@ def extract_exposure(
     year_id: int = None,
 ) -> pd.DataFrame:
     if entity.kind == "risk_factor":
-        data = gbd.get_exposure(entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id)
+        data = gbd.get_exposure(
+            entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id
+        )
         if entity.gbd_id == 341:
             data = process_kidney_dysfunction_exposure(data)
         allowable_measures = [
@@ -305,7 +318,9 @@ def extract_exposure_distribution_weights(
 def extract_relative_risk(
     entity: RiskFactor, location_id: int, get_all_years: bool = False, year_id: int = None
 ) -> pd.DataFrame:
-    data = gbd.get_relative_risk(entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id)
+    data = gbd.get_relative_risk(
+        entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id
+    )
     # TODO: [MIC-4891] Process new relative risk data format properly
     if not data["exposure"].isna().all():
         raise DataAbnormalError(
@@ -321,9 +336,14 @@ def extract_relative_risk(
 
 
 def extract_population_attributable_fraction(
-    entity: Union[RiskFactor, Etiology], location_id: int, get_all_years: bool = False, year_id: int = None
+    entity: Union[RiskFactor, Etiology],
+    location_id: int,
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
-    data = gbd.get_paf(entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id)
+    data = gbd.get_paf(
+        entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id
+    )
     data = data[data.metric_id == METRICS["Percent"]]
     data = data[data.measure_id.isin([MEASURES["YLDs"], MEASURES["YLLs"]])]
     data = filter_to_most_detailed_causes(data)

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Optional, Union
 
 import pandas as pd
 from gbd_mapping import Cause, Covariate, Etiology, ModelableEntity, RiskFactor, Sequela
@@ -30,7 +30,7 @@ def extract_data(
     location_id: List[int],
     validate: bool = True,
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> Union[pd.Series, pd.DataFrame]:
     """Check metadata for the requested entity-measure pair. Pull raw data from
     GBD. The only filtering that occurs is by applicable measure id, metric id,
@@ -155,7 +155,7 @@ def extract_prevalence(
     entity: Union[Cause, Sequela],
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = gbd.get_incidence_prevalence(
         entity_id=entity.gbd_id,
@@ -172,7 +172,7 @@ def extract_incidence_rate(
     entity: Union[Cause, Sequela],
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = gbd.get_incidence_prevalence(
         entity_id=entity.gbd_id,
@@ -189,7 +189,7 @@ def extract_birth_prevalence(
     entity: Union[Cause, Sequela],
     location_id: List[int],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = gbd.get_birth_prevalence(
         entity_id=entity.gbd_id,
@@ -254,7 +254,7 @@ def extract_exposure(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: int,
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     if entity.kind == "risk_factor":
         data = gbd.get_exposure(
@@ -286,7 +286,7 @@ def extract_exposure_standard_deviation(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: int,
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     if entity.kind == "risk_factor" and entity.name in OTHER_MEID:
         data = gbd.get_modelable_entity_draws(
@@ -307,7 +307,7 @@ def extract_exposure_distribution_weights(
     entity: Union[RiskFactor, AlternativeRiskFactor],
     location_id: int,
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = gbd.get_auxiliary_data(
         "exposure_distribution_weights", entity.kind, entity.name, location_id
@@ -339,7 +339,7 @@ def extract_population_attributable_fraction(
     entity: Union[RiskFactor, Etiology],
     location_id: int,
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     data = gbd.get_paf(
         entity.gbd_id, location_id, get_all_years=get_all_years, year_id=year_id

--- a/src/vivarium_inputs/interface.py
+++ b/src/vivarium_inputs/interface.py
@@ -265,6 +265,11 @@ def get_raw_data(
         utility_data.get_location_id(loc) if isinstance(loc, str) else loc for loc in location
     ]
     data = extract.extract_data(
-        entity, measure, location_id, validate=False, get_all_years=get_all_years, year_id=year_id
+        entity,
+        measure,
+        location_id,
+        validate=False,
+        get_all_years=get_all_years,
+        year_id=year_id,
     )
     return data

--- a/src/vivarium_inputs/interface.py
+++ b/src/vivarium_inputs/interface.py
@@ -13,8 +13,7 @@ def get_measure(
     entity: ModelableEntity,
     measure: str,
     location: Union[int, str, List[Union[int, str]]],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     """Pull GBD data for measure and entity and prep for simulation input,
     including scrubbing all GBD conventions to replace IDs with meaningful
@@ -67,11 +66,9 @@ def get_measure(
         Dataframe standardized to the format expected by `vivarium` simulations.
 
     """
-    data = core.get_data(entity, measure, location, get_all_years, year_id)
+    data = core.get_data(entity, measure, location, year_id)
     data = utilities.scrub_gbd_conventions(data, location)
-    validation.validate_for_simulation(
-        data, entity, measure, location, get_all_years, year_id
-    )
+    validation.validate_for_simulation(data, entity, measure, location, year_id)
     data = utilities.split_interval(data, interval_column="age", split_column_prefix="age")
     data = utilities.split_interval(data, interval_column="year", split_column_prefix="year")
     return utilities.sort_hierarchical_data(data)
@@ -79,8 +76,7 @@ def get_measure(
 
 def get_population_structure(
     location: Union[int, str, List[Union[int, str]]],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     """Pull GBD population data for the given location and standardize to the
     expected simulation input format, including scrubbing all GBD conventions
@@ -107,11 +103,9 @@ def get_population_structure(
 
     """
     pop = Population()
-    data = core.get_data(pop, "structure", location, get_all_years, year_id)
+    data = core.get_data(pop, "structure", location, year_id)
     data = utilities.scrub_gbd_conventions(data, location)
-    validation.validate_for_simulation(
-        data, pop, "structure", location, get_all_years, year_id
-    )
+    validation.validate_for_simulation(data, pop, "structure", location, year_id)
     data = utilities.split_interval(data, interval_column="age", split_column_prefix="age")
     data = utilities.split_interval(data, interval_column="year", split_column_prefix="year")
     return utilities.sort_hierarchical_data(data)
@@ -162,8 +156,7 @@ def get_age_bins() -> pd.DataFrame:
 
 def get_demographic_dimensions(
     location: Union[int, str, List[Union[int, str]]],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     """Pull the full demographic dimensions for GBD data, standardized to the
     expected simulation input format, including scrubbing all GBD conventions
@@ -188,13 +181,9 @@ def get_demographic_dimensions(
 
     """
     pop = Population()
-    data = core.get_data(
-        pop, "demographic_dimensions", location, get_all_years=get_all_years, year_id=year_id
-    )
+    data = core.get_data(pop, "demographic_dimensions", location, year_id=year_id)
     data = utilities.scrub_gbd_conventions(data, location)
-    validation.validate_for_simulation(
-        data, pop, "demographic_dimensions", location, get_all_years, year_id
-    )
+    validation.validate_for_simulation(data, pop, "demographic_dimensions", location, year_id)
     data = utilities.split_interval(data, interval_column="age", split_column_prefix="age")
     data = utilities.split_interval(data, interval_column="year", split_column_prefix="year")
     return utilities.sort_hierarchical_data(data)
@@ -204,8 +193,7 @@ def get_raw_data(
     entity: ModelableEntity,
     measure: str,
     location: Union[int, str, List[Union[int, str]]],
-    get_all_years: bool = False,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> Union[pd.Series, pd.DataFrame]:
     """Pull raw data from GBD for the requested entity, measure, and location.
     Skip standard raw validation checks in order to return data that can be
@@ -269,7 +257,6 @@ def get_raw_data(
         measure,
         location_id,
         validate=False,
-        get_all_years=get_all_years,
         year_id=year_id,
     )
     return data

--- a/src/vivarium_inputs/interface.py
+++ b/src/vivarium_inputs/interface.py
@@ -147,7 +147,7 @@ def get_age_bins() -> pd.DataFrame:
 
 
 def get_demographic_dimensions(
-    location: Union[int, str, List[Union[int, str]]], get_all_years: bool = False
+    location: Union[int, str, List[Union[int, str]]], get_all_years: bool = False, year_id: int = None
 ) -> pd.DataFrame:
     """Pull the full demographic dimensions for GBD data, standardized to the
     expected simulation input format, including scrubbing all GBD conventions
@@ -168,10 +168,10 @@ def get_demographic_dimensions(
 
     """
     pop = Population()
-    data = core.get_data(pop, "demographic_dimensions", location, get_all_years)
+    data = core.get_data(pop, "demographic_dimensions", location, get_all_years=get_all_years, year_id=year_id)
     data = utilities.scrub_gbd_conventions(data, location)
     validation.validate_for_simulation(
-        data, pop, "demographic_dimensions", location, get_all_years
+        data, pop, "demographic_dimensions", location, get_all_years, year_id
     )
     data = utilities.split_interval(data, interval_column="age", split_column_prefix="age")
     data = utilities.split_interval(data, interval_column="year", split_column_prefix="year")

--- a/src/vivarium_inputs/interface.py
+++ b/src/vivarium_inputs/interface.py
@@ -56,6 +56,10 @@ def get_measure(
     get_all_years
         Flag indicating whether to get all years. Otherwise, get most recent year.
         Defaults to False.
+    year_id
+        Year for which to extract data. If None, get most recent year if get_all_years
+        is False or all years if get_all_years is True. Cannot be defined if get_all_years
+        is True.
 
     Returns
     -------
@@ -90,6 +94,10 @@ def get_population_structure(
     get_all_years
         Flag indicating whether to get all years. Otherwise, get most recent year.
         Defaults to False.
+    year_id
+        Year for which to extract data. If None, get most recent year if get_all_years
+        is False or all years if get_all_years is True. Cannot be defined if get_all_years
+        is True.
 
     Returns
     -------
@@ -168,6 +176,10 @@ def get_demographic_dimensions(
     get_all_years
         Flag indicating whether to get all years. Otherwise, get most recent year.
         Defaults to False.
+    year_id
+        Year for which to extract data. If None, get most recent year if get_all_years
+        is False or all years if get_all_years is True. Cannot be defined if get_all_years
+        is True.
 
     Returns
     -------
@@ -236,6 +248,10 @@ def get_raw_data(
     get_all_years
         Flag indicating whether to get all years. Otherwise, get most recent year.
         Defaults to False.
+    year_id
+        Year for which to extract data. If None, get most recent year if get_all_years
+        is False or all years if get_all_years is True. Cannot be defined if get_all_years
+        is True.
 
     Returns
     -------

--- a/src/vivarium_inputs/interface.py
+++ b/src/vivarium_inputs/interface.py
@@ -193,6 +193,7 @@ def get_raw_data(
     measure: str,
     location: Union[int, str, List[Union[int, str]]],
     get_all_years: bool = False,
+    year_id: int = None,
 ) -> Union[pd.Series, pd.DataFrame]:
     """Pull raw data from GBD for the requested entity, measure, and location.
     Skip standard raw validation checks in order to return data that can be
@@ -248,6 +249,6 @@ def get_raw_data(
         utility_data.get_location_id(loc) if isinstance(loc, str) else loc for loc in location
     ]
     data = extract.extract_data(
-        entity, measure, location_id, validate=False, get_all_years=get_all_years
+        entity, measure, location_id, validate=False, get_all_years=get_all_years, year_id=year_id
     )
     return data

--- a/src/vivarium_inputs/interface.py
+++ b/src/vivarium_inputs/interface.py
@@ -13,7 +13,7 @@ def get_measure(
     entity: ModelableEntity,
     measure: str,
     location: Union[int, str, List[Union[int, str]]],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     """Pull GBD data for measure and entity and prep for simulation input,
     including scrubbing all GBD conventions to replace IDs with meaningful
@@ -52,8 +52,8 @@ def get_measure(
     location
         Location for which to pull data. This can be a location id as an int, the location name
         as a string, or a list of these two data types.
-    year_id
-        Year for which to extract data. If None, get most recent year. If 'all',
+    years
+        Years for which to extract data. If None, get most recent year. If 'all',
         get all available data. Defaults to None.
 
     Returns
@@ -62,9 +62,9 @@ def get_measure(
         Dataframe standardized to the format expected by `vivarium` simulations.
 
     """
-    data = core.get_data(entity, measure, location, year_id)
+    data = core.get_data(entity, measure, location, years)
     data = utilities.scrub_gbd_conventions(data, location)
-    validation.validate_for_simulation(data, entity, measure, location, year_id)
+    validation.validate_for_simulation(data, entity, measure, location, years)
     data = utilities.split_interval(data, interval_column="age", split_column_prefix="age")
     data = utilities.split_interval(data, interval_column="year", split_column_prefix="year")
     return utilities.sort_hierarchical_data(data)
@@ -72,7 +72,7 @@ def get_measure(
 
 def get_population_structure(
     location: Union[int, str, List[Union[int, str]]],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     """Pull GBD population data for the given location and standardize to the
     expected simulation input format, including scrubbing all GBD conventions
@@ -83,8 +83,8 @@ def get_population_structure(
     ----------
     location
         Location for which to pull population data.
-    year_id
-        Year for which to extract data. If None, get most recent year. If 'all',
+    years
+        Years for which to extract data. If None, get most recent year. If 'all',
         get all available data. Defaults to None.
 
     Returns
@@ -95,9 +95,9 @@ def get_population_structure(
 
     """
     pop = Population()
-    data = core.get_data(pop, "structure", location, year_id)
+    data = core.get_data(pop, "structure", location, years)
     data = utilities.scrub_gbd_conventions(data, location)
-    validation.validate_for_simulation(data, pop, "structure", location, year_id)
+    validation.validate_for_simulation(data, pop, "structure", location, years)
     data = utilities.split_interval(data, interval_column="age", split_column_prefix="age")
     data = utilities.split_interval(data, interval_column="year", split_column_prefix="year")
     return utilities.sort_hierarchical_data(data)
@@ -148,7 +148,7 @@ def get_age_bins() -> pd.DataFrame:
 
 def get_demographic_dimensions(
     location: Union[int, str, List[Union[int, str]]],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     """Pull the full demographic dimensions for GBD data, standardized to the
     expected simulation input format, including scrubbing all GBD conventions
@@ -158,8 +158,8 @@ def get_demographic_dimensions(
     ----------
     location
         Location for which to pull demographic dimension data.
-    year_id
-        Year for which to extract data. If None, get most recent year. If 'all',
+    years
+        Years for which to extract data. If None, get most recent year. If 'all',
         get all available data. Defaults to None.
 
     Returns
@@ -169,9 +169,9 @@ def get_demographic_dimensions(
 
     """
     pop = Population()
-    data = core.get_data(pop, "demographic_dimensions", location, year_id=year_id)
+    data = core.get_data(pop, "demographic_dimensions", location, years=years)
     data = utilities.scrub_gbd_conventions(data, location)
-    validation.validate_for_simulation(data, pop, "demographic_dimensions", location, year_id)
+    validation.validate_for_simulation(data, pop, "demographic_dimensions", location, years)
     data = utilities.split_interval(data, interval_column="age", split_column_prefix="age")
     data = utilities.split_interval(data, interval_column="year", split_column_prefix="year")
     return utilities.sort_hierarchical_data(data)
@@ -181,7 +181,7 @@ def get_raw_data(
     entity: ModelableEntity,
     measure: str,
     location: Union[int, str, List[Union[int, str]]],
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> Union[pd.Series, pd.DataFrame]:
     """Pull raw data from GBD for the requested entity, measure, and location.
     Skip standard raw validation checks in order to return data that can be
@@ -221,8 +221,8 @@ def get_raw_data(
         Measure for which to extract data.
     location
         Location for which to extract data.
-    year_id
-        Year for which to extract data. If None, get most recent year. If 'all',
+    years
+        Years for which to extract data. If None, get most recent year. If 'all',
         get all available data. Defaults to None.
 
     Returns
@@ -241,6 +241,6 @@ def get_raw_data(
         measure,
         location_id,
         validate=False,
-        year_id=year_id,
+        years=years,
     )
     return data

--- a/src/vivarium_inputs/interface.py
+++ b/src/vivarium_inputs/interface.py
@@ -1,5 +1,5 @@
 """Access to vivarium simulation input data."""
-from typing import List, Union
+from typing import List, Optional, Union
 
 import pandas as pd
 from gbd_mapping import ModelableEntity
@@ -14,7 +14,7 @@ def get_measure(
     measure: str,
     location: Union[int, str, List[Union[int, str]]],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     """Pull GBD data for measure and entity and prep for simulation input,
     including scrubbing all GBD conventions to replace IDs with meaningful
@@ -80,7 +80,7 @@ def get_measure(
 def get_population_structure(
     location: Union[int, str, List[Union[int, str]]],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     """Pull GBD population data for the given location and standardize to the
     expected simulation input format, including scrubbing all GBD conventions
@@ -163,7 +163,7 @@ def get_age_bins() -> pd.DataFrame:
 def get_demographic_dimensions(
     location: Union[int, str, List[Union[int, str]]],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     """Pull the full demographic dimensions for GBD data, standardized to the
     expected simulation input format, including scrubbing all GBD conventions
@@ -205,7 +205,7 @@ def get_raw_data(
     measure: str,
     location: Union[int, str, List[Union[int, str]]],
     get_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> Union[pd.Series, pd.DataFrame]:
     """Pull raw data from GBD for the requested entity, measure, and location.
     Skip standard raw validation checks in order to return data that can be

--- a/src/vivarium_inputs/interface.py
+++ b/src/vivarium_inputs/interface.py
@@ -14,6 +14,7 @@ def get_measure(
     measure: str,
     location: Union[int, str, List[Union[int, str]]],
     get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     """Pull GBD data for measure and entity and prep for simulation input,
     including scrubbing all GBD conventions to replace IDs with meaningful
@@ -62,7 +63,7 @@ def get_measure(
         Dataframe standardized to the format expected by `vivarium` simulations.
 
     """
-    data = core.get_data(entity, measure, location, get_all_years)
+    data = core.get_data(entity, measure, location, get_all_years, year_id)
     data = utilities.scrub_gbd_conventions(data, location)
     validation.validate_for_simulation(data, entity, measure, location, get_all_years)
     data = utilities.split_interval(data, interval_column="age", split_column_prefix="age")

--- a/src/vivarium_inputs/interface.py
+++ b/src/vivarium_inputs/interface.py
@@ -65,14 +65,18 @@ def get_measure(
     """
     data = core.get_data(entity, measure, location, get_all_years, year_id)
     data = utilities.scrub_gbd_conventions(data, location)
-    validation.validate_for_simulation(data, entity, measure, location, get_all_years, year_id)
+    validation.validate_for_simulation(
+        data, entity, measure, location, get_all_years, year_id
+    )
     data = utilities.split_interval(data, interval_column="age", split_column_prefix="age")
     data = utilities.split_interval(data, interval_column="year", split_column_prefix="year")
     return utilities.sort_hierarchical_data(data)
 
 
 def get_population_structure(
-    location: Union[int, str, List[Union[int, str]]], get_all_years: bool = False, year_id: int = None
+    location: Union[int, str, List[Union[int, str]]],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     """Pull GBD population data for the given location and standardize to the
     expected simulation input format, including scrubbing all GBD conventions
@@ -97,7 +101,9 @@ def get_population_structure(
     pop = Population()
     data = core.get_data(pop, "structure", location, get_all_years, year_id)
     data = utilities.scrub_gbd_conventions(data, location)
-    validation.validate_for_simulation(data, pop, "structure", location, get_all_years, year_id)
+    validation.validate_for_simulation(
+        data, pop, "structure", location, get_all_years, year_id
+    )
     data = utilities.split_interval(data, interval_column="age", split_column_prefix="age")
     data = utilities.split_interval(data, interval_column="year", split_column_prefix="year")
     return utilities.sort_hierarchical_data(data)
@@ -147,7 +153,9 @@ def get_age_bins() -> pd.DataFrame:
 
 
 def get_demographic_dimensions(
-    location: Union[int, str, List[Union[int, str]]], get_all_years: bool = False, year_id: int = None
+    location: Union[int, str, List[Union[int, str]]],
+    get_all_years: bool = False,
+    year_id: int = None,
 ) -> pd.DataFrame:
     """Pull the full demographic dimensions for GBD data, standardized to the
     expected simulation input format, including scrubbing all GBD conventions
@@ -168,7 +176,9 @@ def get_demographic_dimensions(
 
     """
     pop = Population()
-    data = core.get_data(pop, "demographic_dimensions", location, get_all_years=get_all_years, year_id=year_id)
+    data = core.get_data(
+        pop, "demographic_dimensions", location, get_all_years=get_all_years, year_id=year_id
+    )
     data = utilities.scrub_gbd_conventions(data, location)
     validation.validate_for_simulation(
         data, pop, "demographic_dimensions", location, get_all_years, year_id

--- a/src/vivarium_inputs/interface.py
+++ b/src/vivarium_inputs/interface.py
@@ -65,14 +65,14 @@ def get_measure(
     """
     data = core.get_data(entity, measure, location, get_all_years, year_id)
     data = utilities.scrub_gbd_conventions(data, location)
-    validation.validate_for_simulation(data, entity, measure, location, get_all_years)
+    validation.validate_for_simulation(data, entity, measure, location, get_all_years, year_id)
     data = utilities.split_interval(data, interval_column="age", split_column_prefix="age")
     data = utilities.split_interval(data, interval_column="year", split_column_prefix="year")
     return utilities.sort_hierarchical_data(data)
 
 
 def get_population_structure(
-    location: Union[int, str, List[Union[int, str]]], get_all_years: bool = False
+    location: Union[int, str, List[Union[int, str]]], get_all_years: bool = False, year_id: int = None
 ) -> pd.DataFrame:
     """Pull GBD population data for the given location and standardize to the
     expected simulation input format, including scrubbing all GBD conventions
@@ -95,9 +95,9 @@ def get_population_structure(
 
     """
     pop = Population()
-    data = core.get_data(pop, "structure", location, get_all_years)
+    data = core.get_data(pop, "structure", location, get_all_years, year_id)
     data = utilities.scrub_gbd_conventions(data, location)
-    validation.validate_for_simulation(data, pop, "structure", location, get_all_years)
+    validation.validate_for_simulation(data, pop, "structure", location, get_all_years, year_id)
     data = utilities.split_interval(data, interval_column="age", split_column_prefix="age")
     data = utilities.split_interval(data, interval_column="year", split_column_prefix="year")
     return utilities.sort_hierarchical_data(data)

--- a/src/vivarium_inputs/utility_data.py
+++ b/src/vivarium_inputs/utility_data.py
@@ -73,9 +73,7 @@ def get_demographic_dimensions(
         years = range(min(estimation_years), max(estimation_years) + 1)
     else:
         if years and years not in estimation_years:
-            raise ValueError(
-                f"years must be in {estimation_years}. You provided {years}."
-            )
+            raise ValueError(f"years must be in {estimation_years}. You provided {years}.")
         years = [years] if years else [gbd.get_most_recent_year()]
     sexes = [SEXES["Male"], SEXES["Female"]]
     location = [location_id] if isinstance(location_id, int) else location_id

--- a/src/vivarium_inputs/utility_data.py
+++ b/src/vivarium_inputs/utility_data.py
@@ -63,20 +63,16 @@ def get_location_id_parents(location_id: Union[int, List[int]]) -> Dict[int, Lis
 
 def get_demographic_dimensions(
     location_id: Union[int, List[int]],
-    get_all_years: bool = False,
     draws: bool = False,
     value: float = None,
-    year_id: Optional[int] = None,
+    year_id: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     ages = get_age_group_ids()
-    if get_all_years:
+    if year_id == 'all':
         estimation_years = get_estimation_years()
         years = range(min(estimation_years), max(estimation_years) + 1)
     else:
-        if year_id:
-            years = [year_id]
-        else:
-            years = [gbd.get_most_recent_year()]
+        years = [year_id] if year_id else [gbd.get_most_recent_year()]
     sexes = [SEXES["Male"], SEXES["Female"]]
     location = [location_id] if isinstance(location_id, int) else location_id
     values = [location, sexes, ages, years]

--- a/src/vivarium_inputs/utility_data.py
+++ b/src/vivarium_inputs/utility_data.py
@@ -66,13 +66,17 @@ def get_demographic_dimensions(
     get_all_years: bool = False,
     draws: bool = False,
     value: float = None,
+    year_id: int = None,
 ) -> pd.DataFrame:
     ages = get_age_group_ids()
     if get_all_years:
         estimation_years = get_estimation_years()
         years = range(min(estimation_years), max(estimation_years) + 1)
     else:
-        years = [gbd.get_most_recent_year()]
+        if year_id:
+            years = [year_id]
+        else:
+            years = [gbd.get_most_recent_year()]
     sexes = [SEXES["Male"], SEXES["Female"]]
     location = [location_id] if isinstance(location_id, int) else location_id
     values = [location, sexes, ages, years]

--- a/src/vivarium_inputs/utility_data.py
+++ b/src/vivarium_inputs/utility_data.py
@@ -74,7 +74,7 @@ def get_demographic_dimensions(
     else:
         if years and years not in estimation_years:
             raise ValueError(
-                f"year must be in {estimation_years}. You provided {years}."
+                f"years must be in {estimation_years}. You provided {years}."
             )
         years = [years] if years else [gbd.get_most_recent_year()]
     sexes = [SEXES["Male"], SEXES["Female"]]

--- a/src/vivarium_inputs/utility_data.py
+++ b/src/vivarium_inputs/utility_data.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 import pandas as pd
 from gbd_mapping import RiskFactor
@@ -66,7 +66,7 @@ def get_demographic_dimensions(
     get_all_years: bool = False,
     draws: bool = False,
     value: float = None,
-    year_id: int = None,
+    year_id: Optional[int] = None,
 ) -> pd.DataFrame:
     ages = get_age_group_ids()
     if get_all_years:

--- a/src/vivarium_inputs/utility_data.py
+++ b/src/vivarium_inputs/utility_data.py
@@ -65,18 +65,18 @@ def get_demographic_dimensions(
     location_id: Union[int, List[int]],
     draws: bool = False,
     value: float = None,
-    year_id: Optional[Union[int, str, List[int]]] = None,
+    years: Optional[Union[int, str, List[int]]] = None,
 ) -> pd.DataFrame:
     ages = get_age_group_ids()
     estimation_years = get_estimation_years()
-    if year_id == "all":
+    if years == "all":
         years = range(min(estimation_years), max(estimation_years) + 1)
     else:
-        if year_id and year_id not in estimation_years:
+        if years and years not in estimation_years:
             raise ValueError(
-                f"year_id must be in {estimation_years}. You provided {year_id}."
+                f"year must be in {estimation_years}. You provided {years}."
             )
-        years = [year_id] if year_id else [gbd.get_most_recent_year()]
+        years = [years] if years else [gbd.get_most_recent_year()]
     sexes = [SEXES["Male"], SEXES["Female"]]
     location = [location_id] if isinstance(location_id, int) else location_id
     values = [location, sexes, ages, years]

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -1326,9 +1326,6 @@ def validate_demographic_dimensions(
         values.
 
     """
-    import pdb
-
-    pdb.set_trace()
     validate_demographic_columns(data, context)
 
 

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -157,7 +157,7 @@ def validate_for_simulation(
     if measure not in validators:
         raise NotImplementedError()
 
-    if not check_all_years:
+    if year_id != 'all':
         if year_id:
             context_args["years"] = pd.DataFrame(
                 {"year_start": year_id, "year_end": year_id + 1}, index=[0]

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -84,6 +84,7 @@ def validate_for_simulation(
     measure: str,
     location: Union[int, str, List[Union[int, str]]],
     check_all_years: bool = False,
+    year_id: int = None,
     **context_args,
 ) -> None:
     """Validate data conforms to the format that is expected by the simulation
@@ -158,10 +159,13 @@ def validate_for_simulation(
         raise NotImplementedError()
 
     if not check_all_years:
-        most_recent_year = gbd.get_most_recent_year()
-        context_args["years"] = pd.DataFrame(
-            {"year_start": most_recent_year, "year_end": most_recent_year + 1}, index=[0]
-        )
+        if year_id:
+            context_args["years"] = pd.DataFrame({"year_start": year_id, "year_end": year_id + 1}, index=[0])
+        else:
+            most_recent_year = gbd.get_most_recent_year()
+            context_args["years"] = pd.DataFrame(
+                {"year_start": most_recent_year, "year_end": most_recent_year + 1}, index=[0]
+            )
 
     # Coerce to location names
     if not isinstance(location, list):

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -160,7 +160,9 @@ def validate_for_simulation(
 
     if not check_all_years:
         if year_id:
-            context_args["years"] = pd.DataFrame({"year_start": year_id, "year_end": year_id + 1}, index=[0])
+            context_args["years"] = pd.DataFrame(
+                {"year_start": year_id, "year_end": year_id + 1}, index=[0]
+            )
         else:
             most_recent_year = gbd.get_most_recent_year()
             context_args["years"] = pd.DataFrame(
@@ -1324,7 +1326,9 @@ def validate_demographic_dimensions(
         values.
 
     """
-    import pdb; pdb.set_trace()
+    import pdb
+
+    pdb.set_trace()
     validate_demographic_columns(data, context)
 
 

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -83,7 +83,6 @@ def validate_for_simulation(
     entity: ModelableEntity,
     measure: str,
     location: Union[int, str, List[Union[int, str]]],
-    check_all_years: bool = False,
     year_id: Optional[int] = None,
     **context_args,
 ) -> None:

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -1542,7 +1542,7 @@ def validate_year_column(data: pd.DataFrame, context: SimulationValidationContex
 
     if not sorted(data_years) == sorted(expected_years):
         raise DataTransformationError(
-            f"Data was expected to contain years {expected_years.values}. The data provided contains years {data_years.values}."
+            f"Data was expected to contain years {expected_years.values}. The data provided contains years {data_years}."
         )
 
 

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -1541,8 +1541,10 @@ def validate_year_column(data: pd.DataFrame, context: SimulationValidationContex
     data_years = data.index.levels[data.index.names.index("year")]
 
     if not sorted(data_years) == sorted(expected_years):
+        formatted_expected_years = [interval.left for interval in sorted(expected_years)]
+        formatted_data_years = [interval.left for interval in sorted(expected_years)]
         raise DataTransformationError(
-            f"Data was expected to contain years {expected_years.values}. The data provided contains years {data_years}."
+            f"Data was expected to contain years {formatted_expected_years}. The data provided contains years {formatted_data_years}."
         )
 
 

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -84,7 +84,7 @@ def validate_for_simulation(
     measure: str,
     location: Union[int, str, List[Union[int, str]]],
     check_all_years: bool = False,
-    year_id: int = None,
+    year_id: Optional[int] = None,
     **context_args,
 ) -> None:
     """Validate data conforms to the format that is expected by the simulation

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -1539,7 +1539,7 @@ def validate_year_column(data: pd.DataFrame, context: SimulationValidationContex
 
     if not sorted(data_years) == sorted(expected_years):
         formatted_expected_years = [interval.left for interval in sorted(expected_years)]
-        formatted_data_years = [interval.left for interval in sorted(expected_years)]
+        formatted_data_years = [interval.left for interval in sorted(data_years)]
         raise DataTransformationError(
             f"Data was expected to contain years {formatted_expected_years}. The data provided contains years {formatted_data_years}."
         )

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -83,7 +83,7 @@ def validate_for_simulation(
     entity: ModelableEntity,
     measure: str,
     location: Union[int, str, List[Union[int, str]]],
-    year_id: Optional[int] = None,
+    years: Optional[int] = None,
     **context_args,
 ) -> None:
     """Validate data conforms to the format that is expected by the simulation
@@ -157,10 +157,10 @@ def validate_for_simulation(
     if measure not in validators:
         raise NotImplementedError()
 
-    if year_id != "all":
-        if year_id:
+    if years != "all":
+        if years:
             context_args["years"] = pd.DataFrame(
-                {"year_start": year_id, "year_end": year_id + 1}, index=[0]
+                {"year_start": years, "year_end": years + 1}, index=[0]
             )
         else:
             most_recent_year = gbd.get_most_recent_year()

--- a/src/vivarium_inputs/validation/sim.py
+++ b/src/vivarium_inputs/validation/sim.py
@@ -1324,6 +1324,7 @@ def validate_demographic_dimensions(
         values.
 
     """
+    import pdb; pdb.set_trace()
     validate_demographic_columns(data, context)
 
 
@@ -1537,7 +1538,7 @@ def validate_year_column(data: pd.DataFrame, context: SimulationValidationContex
 
     if not sorted(data_years) == sorted(expected_years):
         raise DataTransformationError(
-            "Year_start and year_end must cover [1990, 2021] in intervals of one year or only be most recent year."
+            f"Data was expected to contain years {expected_years.values}. The data provided contains years {data_years.values}."
         )
 
 

--- a/tests/extract/test_core.py
+++ b/tests/extract/test_core.py
@@ -110,15 +110,15 @@ def test_core_causelike(entity, measure, location):
 def test_year_id_causelike(entity, measure, location, year_id):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
-    if (entity_expected_measure_ids & measure_id):
+    if entity_expected_measure_ids & measure_id:
         if year_id != 1900:
             df = core.get_data(entity_name, measure_name, location, year_id=year_id)
             if year_id == None:
-                assert set(df.reset_index()['year_id']) == set([2021])
+                assert set(df.reset_index()["year_id"]) == set([2021])
             elif year_id == 2019:
-                assert set(df.reset_index()['year_id']) == set([2019])
+                assert set(df.reset_index()["year_id"]) == set([2019])
         else:
-            with pytest.raises(ValueError, match='year_id must be one of'):
+            with pytest.raises(ValueError, match="year_id must be one of"):
                 df = core.get_data(entity_name, measure_name, location, year_id=year_id)
 
 
@@ -184,15 +184,15 @@ def test_core_risklike(entity, measure, location):
 def test_year_id_risklike(entity, measure, location, year_id):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
-    if (entity_expected_measure_ids & measure_id):
+    if entity_expected_measure_ids & measure_id:
         if year_id != 1900:
             df = core.get_data(entity_name, measure_name, location, year_id=year_id)
             if year_id == None:
-                assert set(df.reset_index()['year_id']) == set([2021])
+                assert set(df.reset_index()["year_id"]) == set([2021])
             elif year_id == 2019:
-                assert set(df.reset_index()['year_id']) == set([2019])
+                assert set(df.reset_index()["year_id"]) == set([2019])
         else:
-            with pytest.raises(ValueError, match='year_id must be one of'):
+            with pytest.raises(ValueError, match="year_id must be one of"):
                 df = core.get_data(entity_name, measure_name, location, year_id=year_id)
 
 
@@ -217,12 +217,12 @@ def test_core_covariatelike(entity, measure, location):
 def test_year_id_covariatelike(entity, measure, location, year_id):
     if year_id == None:
         df = core.get_data(entity, measure, location, year_id=year_id)
-        assert set(df.reset_index()['year_id']) == set([2021])
+        assert set(df.reset_index()["year_id"]) == set([2021])
     elif year_id == 2019:
         df = core.get_data(entity, measure, location, year_id=year_id)
-        assert set(df.reset_index()['year_id']) == set([2019])
+        assert set(df.reset_index()["year_id"]) == set([2019])
     else:
-        with pytest.raises(ValueError, match='year_id must be one of'):
+        with pytest.raises(ValueError, match="year_id must be one of"):
             df = core.get_data(entity, measure, location, year_id=year_id)
 
 
@@ -245,14 +245,20 @@ def test_core_population(measures):
 def test_year_id_population(measures, year_id):
     pop = ModelableEntity("ignored", "population", None)
     if year_id == None:
-        df = core.get_data(pop, measures, utility_data.get_location_id("India"), year_id=year_id)
-        assert set(df.reset_index()['year_id']) == set([2021])
+        df = core.get_data(
+            pop, measures, utility_data.get_location_id("India"), year_id=year_id
+        )
+        assert set(df.reset_index()["year_id"]) == set([2021])
     elif year_id == 2019:
-        df = core.get_data(pop, measures, utility_data.get_location_id("India"), year_id=year_id)
-        assert set(df.reset_index()['year_id']) == set([2019])
+        df = core.get_data(
+            pop, measures, utility_data.get_location_id("India"), year_id=year_id
+        )
+        assert set(df.reset_index()["year_id"]) == set([2019])
     elif year_id == 1900:
-        with pytest.raises(ValueError, match='year_id must be one of'):
-            df = core.get_data(pop, measures, utility_data.get_location_id("India"), year_id=year_id)
+        with pytest.raises(ValueError, match="year_id must be one of"):
+            df = core.get_data(
+                pop, measures, utility_data.get_location_id("India"), year_id=year_id
+            )
 
 
 # TODO - Underlying problem with gbd access. Remove when corrected.
@@ -300,5 +306,9 @@ def test_pulling_multiple_locations(entity, measure, locations):
 
 
 def test_year_args_compatibility():
-    with pytest.raises(Exception, match='cannot provide a year ID and set get_all_years to True'):
-        df = core.get_data(causes.measles, 'incidence_rate', 'India', get_all_years=True, year_id=2021)
+    with pytest.raises(
+        Exception, match="cannot provide a year ID and set get_all_years to True"
+    ):
+        df = core.get_data(
+            causes.measles, "incidence_rate", "India", get_all_years=True, year_id=2021
+        )

--- a/tests/extract/test_core.py
+++ b/tests/extract/test_core.py
@@ -110,15 +110,16 @@ def test_core_causelike(entity, measure, location):
 def test_core_years_causelike(entity, measure, location, year_id):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
-    if (entity_expected_measure_ids & measure_id & year_id!=1900):
-        df = core.get_data(entity_name, measure_name, location, year_id=year_id)
-        if year_id == None:
-            assert set(df['year_id']) == set(utility_data.get_estimation_years())
-        elif year_id == 2019:
-            assert set(df['year_id']) == set([2019])
-    elif year_id == 1900:
-        with pytest.raises(Exception):
+    if (entity_expected_measure_ids & measure_id):
+        if year_id != 1900:
             df = core.get_data(entity_name, measure_name, location, year_id=year_id)
+            if year_id == None:
+                assert set(df.reset_index()['year_id']) == set([2021])
+            elif year_id == 2019:
+                assert set(df.reset_index()['year_id']) == set([2019])
+        else:
+            with pytest.raises(ValueError):
+                df = core.get_data(entity_name, measure_name, location, year_id=year_id)
 
 
 class MRFlag(IntFlag):
@@ -177,21 +178,22 @@ def test_core_risklike(entity, measure, location):
 
 
 @pytest.mark.parametrize("entity", entity_r, ids=lambda x: x[0].name)
-@pytest.mark.parametrize("measure", measures, ids=lambda x: x[0])
-@pytest.mark.parametrize("location", locations)
+@pytest.mark.parametrize("measure", measures_r, ids=lambda x: x[0])
+@pytest.mark.parametrize("location", locations_r)
 @pytest.mark.parametrize("year_id", [None, 2019, 1900])
 def test_core_years_risklike(entity, measure, location, year_id):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
-    if (entity_expected_measure_ids & measure_id & year_id!=1900):
-        df = core.get_data(entity_name, measure_name, location, year_id=year_id)
-        if year_id == None:
-            assert set(df['year_id']) == set(utility_data.get_estimation_years())
-        elif year_id == 2019:
-            assert set(df['year_id']) == set([2019])
-    elif year_id == 1900:
-        with pytest.raises(Exception):
+    if (entity_expected_measure_ids & measure_id):
+        if year_id != 1900:
             df = core.get_data(entity_name, measure_name, location, year_id=year_id)
+            if year_id == None:
+                assert set(df['year_id']) == set(utility_data.get_estimation_years())
+            elif year_id == 2019:
+                assert set(df['year_id']) == set([2019])
+        else:
+            with pytest.raises(Exception):
+                df = core.get_data(entity_name, measure_name, location, year_id=year_id)
 
 
 entity_cov = [

--- a/tests/extract/test_core.py
+++ b/tests/extract/test_core.py
@@ -118,7 +118,7 @@ def test_core_years_causelike(entity, measure, location, year_id):
             elif year_id == 2019:
                 assert set(df.reset_index()['year_id']) == set([2019])
         else:
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match='expected to contain years'):
                 df = core.get_data(entity_name, measure_name, location, year_id=year_id)
 
 
@@ -188,11 +188,11 @@ def test_core_years_risklike(entity, measure, location, year_id):
         if year_id != 1900:
             df = core.get_data(entity_name, measure_name, location, year_id=year_id)
             if year_id == None:
-                assert set(df['year_id']) == set(utility_data.get_estimation_years())
+                assert set(df.reset_index()['year_id']) == set([2021])
             elif year_id == 2019:
-                assert set(df['year_id']) == set([2019])
+                assert set(df.reset_index()['year_id']) == set([2019])
         else:
-            with pytest.raises(Exception):
+            with pytest.raises(ValueError, match='expected to contain years'):
                 df = core.get_data(entity_name, measure_name, location, year_id=year_id)
 
 
@@ -216,11 +216,11 @@ def test_core_covariatelike(entity, measure, location):
 def test_core_years_covariatelike(entity, measure, location, year_id):
     df = core.get_data(entity, measure, location, year_id=year_id)
     if year_id == None:
-        assert set(df['year_id']) == set(utility_data.get_estimation_years())
+        assert set(df.reset_index()['year_id']) == set([2021])
     elif year_id == 2019:
-        assert set(df['year_id']) == set([2019])
+        assert set(df.reset_index()['year_id']) == set([2019])
     elif year_id == 1900:
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError, match='expected to contain years'):
             df = core.get_data(entity, measure, location, year_id=year_id)
 
 
@@ -244,11 +244,11 @@ def test_core_years_population(measures, year_id):
     pop = ModelableEntity("ignored", "population", None)
     df = core.get_data(pop, measures, utility_data.get_location_id("India"), year_id=year_id)
     if year_id == None:
-        assert set(df['year_id']) == set(utility_data.get_estimation_years())
+        assert set(df.reset_index()['year_id']) == set([2021])
     elif year_id == 2019:
-        assert set(df['year_id']) == set([2019])
+        assert set(df.reset_index()['year_id']) == set([2019])
     elif year_id == 1900:
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError, match='expected to contain years'):
             df = core.get_data(pop, measures, utility_data.get_location_id("India"), year_id=year_id)
 
 
@@ -300,7 +300,7 @@ def test_pulling_multiple_locations(entity, measure, locations):
 def test_year_args_checks(year_id):
     if year_id == 2019:
         with pytest.raises(Exception, match='cannot provide a year ID and set get_all_years to True'):
-            df = core.get_data(entity_name, measure_name, location, get_all_years, year_id)
+            df = core.get_data('measles', 'incidence_rate', 'India', get_all_years=True, year_id=year_id)
     if year_id == 1900:
         with pytest.raises(Exception, match='year_id must be one of'):
-            df = core.get_data(entity_name, measure_name, location, year_id=year_id)
+            df = core.get_data('measles', 'incidence_rate', 'India', year_id=year_id)

--- a/tests/extract/test_core.py
+++ b/tests/extract/test_core.py
@@ -32,8 +32,10 @@ def check_year_in_data(entity, measure, location, year_id):
             assert set(df.reset_index()["year_id"]) == set([2021])
         elif year_id == 2019:
             assert set(df.reset_index()["year_id"]) == set([2019])
+        elif year_id == 'all':
+            assert set(df.reset_index()["year_id"]) == set(range(1990,2023))
     else: # assumes that year_id is out of range if not 2019
-        with pytest.raises(ValueError, match="year_id must be one of"):
+        with pytest.raises(ValueError, match="year_id must be in"):
             df = core.get_data(entity, measure, location, year_id=year_id)
 
 
@@ -118,7 +120,7 @@ def test_core_causelike(entity, measure, location):
 @pytest.mark.parametrize("entity", entity, ids=lambda x: x[0].name)
 @pytest.mark.parametrize("measure", measures, ids=lambda x: x[0])
 @pytest.mark.parametrize("location", locations)
-@pytest.mark.parametrize("year_id", [None, 2019, 1900])
+@pytest.mark.parametrize("year_id", [None, 2019, 1900, 'all'])
 def test_year_id_causelike(entity, measure, location, year_id):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
@@ -184,7 +186,7 @@ def test_core_risklike(entity, measure, location):
 @pytest.mark.parametrize("entity", entity_r, ids=lambda x: x[0].name)
 @pytest.mark.parametrize("measure", measures_r, ids=lambda x: x[0])
 @pytest.mark.parametrize("location", locations_r)
-@pytest.mark.parametrize("year_id", [None, 2019, 1900])
+@pytest.mark.parametrize("year_id", [None, 2019, 1900, 'all'])
 def test_year_id_risklike(entity, measure, location, year_id):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
@@ -209,7 +211,7 @@ def test_core_covariatelike(entity, measure, location):
 @pytest.mark.parametrize("entity", entity_cov, ids=lambda x: x.name)
 @pytest.mark.parametrize("measure", measures_cov, ids=lambda x: x)
 @pytest.mark.parametrize("location", locations_cov)
-@pytest.mark.parametrize("year_id", [None, 2019, 1900])
+@pytest.mark.parametrize("year_id", [None, 2019, 1900, 'all'])
 def test_year_id_covariatelike(entity, measure, location, year_id):
     check_year_in_data(entity, measure, location, year_id=year_id)
 
@@ -229,7 +231,7 @@ def test_core_population(measures):
 
 
 @pytest.mark.parametrize("measure", ["structure", "demographic_dimensions"])
-@pytest.mark.parametrize("year_id", [None, 2019, 1900])
+@pytest.mark.parametrize("year_id", [None, 2019, 1900, 'all'])
 def test_year_id_population(measure, year_id):
     pop = ModelableEntity("ignored", "population", None)
     location = utility_data.get_location_id("India")
@@ -279,11 +281,3 @@ def test_pulling_multiple_locations(entity, measure, locations):
     tester = success_expected if (entity_expected_measure_ids & measure_id) else fail_expected
     df = tester(entity_name, measure_name, locations)
 
-
-def test_year_args_compatibility():
-    with pytest.raises(
-        ValueError, match="cannot provide a year ID and set get_all_years to True"
-    ):
-        df = core.get_data(
-            causes.measles, "incidence_rate", "India", get_all_years=True, year_id=2021
-        )

--- a/tests/extract/test_core.py
+++ b/tests/extract/test_core.py
@@ -26,15 +26,15 @@ def fail_expected(entity_name, measure_name, location):
 
 
 def check_year_in_data(entity, measure, location, year_id):
-     if year_id != 1900:
-         df = core.get_data(entity, measure, location, year_id=year_id)
-         if year_id == None:
-             assert set(df.reset_index()["year_id"]) == set([2021])
-         elif year_id == 2019:
-             assert set(df.reset_index()["year_id"]) == set([2019])
-     else:
-         with pytest.raises(ValueError, match="year_id must be one of"):
-             df = core.get_data(entity, measure, location, year_id=year_id)
+    if year_id != 1900:
+        df = core.get_data(entity, measure, location, year_id=year_id)
+        if year_id == None:
+            assert set(df.reset_index()["year_id"]) == set([2021])
+        elif year_id == 2019:
+            assert set(df.reset_index()["year_id"]) == set([2019])
+    else:
+        with pytest.raises(ValueError, match="year_id must be one of"):
+            df = core.get_data(entity, measure, location, year_id=year_id)
 
 
 class MCFlag(IntFlag):

--- a/tests/extract/test_core.py
+++ b/tests/extract/test_core.py
@@ -25,6 +25,18 @@ def fail_expected(entity_name, measure_name, location):
         df = core.get_data(entity_name, measure_name, location)
 
 
+def check_year_in_data(entity, measure, location, year_id):
+     if year_id != 1900:
+         df = core.get_data(entity, measure, location, year_id=year_id)
+         if year_id == None:
+             assert set(df.reset_index()["year_id"]) == set([2021])
+         elif year_id == 2019:
+             assert set(df.reset_index()["year_id"]) == set([2019])
+     else:
+         with pytest.raises(ValueError, match="year_id must be one of"):
+             df = core.get_data(entity, measure, location, year_id=year_id)
+
+
 class MCFlag(IntFlag):
     """
     Use the idea of a bit field with support from python's enum type IntFlag
@@ -111,15 +123,16 @@ def test_year_id_causelike(entity, measure, location, year_id):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
     if entity_expected_measure_ids & measure_id:
-        if year_id != 1900:
-            df = core.get_data(entity_name, measure_name, location, year_id=year_id)
-            if year_id == None:
-                assert set(df.reset_index()["year_id"]) == set([2021])
-            elif year_id == 2019:
-                assert set(df.reset_index()["year_id"]) == set([2019])
-        else:
-            with pytest.raises(ValueError, match="year_id must be one of"):
-                df = core.get_data(entity_name, measure_name, location, year_id=year_id)
+        check_year_in_data(entity_name, measure_name, location, year_id=year_id)
+        # if year_id != 1900:
+        #     df = core.get_data(entity_name, measure_name, location, year_id=year_id)
+        #     if year_id == None:
+        #         assert set(df.reset_index()["year_id"]) == set([2021])
+        #     elif year_id == 2019:
+        #         assert set(df.reset_index()["year_id"]) == set([2019])
+        # else:
+        #     with pytest.raises(ValueError, match="year_id must be one of"):
+        #         df = core.get_data(entity_name, measure_name, location, year_id=year_id)
 
 
 class MRFlag(IntFlag):
@@ -185,15 +198,16 @@ def test_year_id_risklike(entity, measure, location, year_id):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
     if entity_expected_measure_ids & measure_id:
-        if year_id != 1900:
-            df = core.get_data(entity_name, measure_name, location, year_id=year_id)
-            if year_id == None:
-                assert set(df.reset_index()["year_id"]) == set([2021])
-            elif year_id == 2019:
-                assert set(df.reset_index()["year_id"]) == set([2019])
-        else:
-            with pytest.raises(ValueError, match="year_id must be one of"):
-                df = core.get_data(entity_name, measure_name, location, year_id=year_id)
+        check_year_in_data(entity_name, measure_name, location, year_id=year_id)
+        # if year_id != 1900:
+        #     df = core.get_data(entity_name, measure_name, location, year_id=year_id)
+        #     if year_id == None:
+        #         assert set(df.reset_index()["year_id"]) == set([2021])
+        #     elif year_id == 2019:
+        #         assert set(df.reset_index()["year_id"]) == set([2019])
+        # else:
+        #     with pytest.raises(ValueError, match="year_id must be one of"):
+        #         df = core.get_data(entity_name, measure_name, location, year_id=year_id)
 
 
 entity_cov = [
@@ -215,15 +229,16 @@ def test_core_covariatelike(entity, measure, location):
 @pytest.mark.parametrize("location", locations_cov)
 @pytest.mark.parametrize("year_id", [None, 2019, 1900])
 def test_year_id_covariatelike(entity, measure, location, year_id):
-    if year_id == None:
-        df = core.get_data(entity, measure, location, year_id=year_id)
-        assert set(df.reset_index()["year_id"]) == set([2021])
-    elif year_id == 2019:
-        df = core.get_data(entity, measure, location, year_id=year_id)
-        assert set(df.reset_index()["year_id"]) == set([2019])
-    else:
-        with pytest.raises(ValueError, match="year_id must be one of"):
-            df = core.get_data(entity, measure, location, year_id=year_id)
+    check_year_in_data(entity, measure, location, year_id=year_id)
+    # if year_id == None:
+    #     df = core.get_data(entity, measure, location, year_id=year_id)
+    #     assert set(df.reset_index()["year_id"]) == set([2021])
+    # elif year_id == 2019:
+    #     df = core.get_data(entity, measure, location, year_id=year_id)
+    #     assert set(df.reset_index()["year_id"]) == set([2019])
+    # else:
+    #     with pytest.raises(ValueError, match="year_id must be one of"):
+    #         df = core.get_data(entity, measure, location, year_id=year_id)
 
 
 @pytest.mark.parametrize(
@@ -240,25 +255,27 @@ def test_core_population(measures):
     df = core.get_data(pop, measures, utility_data.get_location_id("India"))
 
 
-@pytest.mark.parametrize("measures", ["structure", "demographic_dimensions"])
+@pytest.mark.parametrize("measure", ["structure", "demographic_dimensions"])
 @pytest.mark.parametrize("year_id", [None, 2019, 1900])
-def test_year_id_population(measures, year_id):
+def test_year_id_population(measure, year_id):
     pop = ModelableEntity("ignored", "population", None)
-    if year_id == None:
-        df = core.get_data(
-            pop, measures, utility_data.get_location_id("India"), year_id=year_id
-        )
-        assert set(df.reset_index()["year_id"]) == set([2021])
-    elif year_id == 2019:
-        df = core.get_data(
-            pop, measures, utility_data.get_location_id("India"), year_id=year_id
-        )
-        assert set(df.reset_index()["year_id"]) == set([2019])
-    elif year_id == 1900:
-        with pytest.raises(ValueError, match="year_id must be one of"):
-            df = core.get_data(
-                pop, measures, utility_data.get_location_id("India"), year_id=year_id
-            )
+    location = utility_data.get_location_id("India")
+    check_year_in_data(pop, measure, location, year_id=year_id)
+    # if year_id == None:
+    #     df = core.get_data(
+    #         pop, measures, utility_data.get_location_id("India"), year_id=year_id
+    #     )
+    #     assert set(df.reset_index()["year_id"]) == set([2021])
+    # elif year_id == 2019:
+    #     df = core.get_data(
+    #         pop, measures, utility_data.get_location_id("India"), year_id=year_id
+    #     )
+    #     assert set(df.reset_index()["year_id"]) == set([2019])
+    # elif year_id == 1900:
+    #     with pytest.raises(ValueError, match="year_id must be one of"):
+    #         df = core.get_data(
+    #             pop, measures, utility_data.get_location_id("India"), year_id=year_id
+    #         )
 
 
 # TODO - Underlying problem with gbd access. Remove when corrected.
@@ -307,7 +324,7 @@ def test_pulling_multiple_locations(entity, measure, locations):
 
 def test_year_args_compatibility():
     with pytest.raises(
-        Exception, match="cannot provide a year ID and set get_all_years to True"
+        ValueError, match="cannot provide a year ID and set get_all_years to True"
     ):
         df = core.get_data(
             causes.measles, "incidence_rate", "India", get_all_years=True, year_id=2021

--- a/tests/extract/test_core.py
+++ b/tests/extract/test_core.py
@@ -25,18 +25,18 @@ def fail_expected(entity_name, measure_name, location):
         df = core.get_data(entity_name, measure_name, location)
 
 
-def check_year_in_data(entity, measure, location, year_id):
-    if year_id != 1900:
-        df = core.get_data(entity, measure, location, year_id=year_id)
-        if year_id == None:
+def check_year_in_data(entity, measure, location, years):
+    if years != 1900:
+        df = core.get_data(entity, measure, location, years=years)
+        if years == None:
             assert set(df.reset_index()["year_id"]) == set([2021])
-        elif year_id == 2019:
+        elif years == 2019:
             assert set(df.reset_index()["year_id"]) == set([2019])
-        elif year_id == 'all':
+        elif years == 'all':
             assert set(df.reset_index()["year_id"]) == set(range(1990,2023))
-    else: # year_id is out of range if not one of above
-        with pytest.raises(ValueError, match="year_id must be in"):
-            df = core.get_data(entity, measure, location, year_id=year_id)
+    else:
+        with pytest.raises(ValueError, match="years must be in"):
+            df = core.get_data(entity, measure, location, years=years)
 
 
 class MCFlag(IntFlag):
@@ -120,12 +120,12 @@ def test_core_causelike(entity, measure, location):
 @pytest.mark.parametrize("entity", entity, ids=lambda x: x[0].name)
 @pytest.mark.parametrize("measure", measures, ids=lambda x: x[0])
 @pytest.mark.parametrize("location", locations)
-@pytest.mark.parametrize("year_id", [None, 2019, 1900, 'all'])
-def test_year_id_causelike(entity, measure, location, year_id):
+@pytest.mark.parametrize("years", [None, 2019, 1900, 'all'])
+def test_year_id_causelike(entity, measure, location, years):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
     if entity_expected_measure_ids & measure_id:
-        check_year_in_data(entity_name, measure_name, location, year_id=year_id)
+        check_year_in_data(entity_name, measure_name, location, years=years)
 
 
 class MRFlag(IntFlag):
@@ -186,12 +186,12 @@ def test_core_risklike(entity, measure, location):
 @pytest.mark.parametrize("entity", entity_r, ids=lambda x: x[0].name)
 @pytest.mark.parametrize("measure", measures_r, ids=lambda x: x[0])
 @pytest.mark.parametrize("location", locations_r)
-@pytest.mark.parametrize("year_id", [None, 2019, 1900, 'all'])
-def test_year_id_risklike(entity, measure, location, year_id):
+@pytest.mark.parametrize("years", [None, 2019, 1900, 'all'])
+def test_year_id_risklike(entity, measure, location, years):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
     if entity_expected_measure_ids & measure_id:
-        check_year_in_data(entity_name, measure_name, location, year_id=year_id)
+        check_year_in_data(entity_name, measure_name, location, years=years)
 
 
 entity_cov = [
@@ -211,9 +211,9 @@ def test_core_covariatelike(entity, measure, location):
 @pytest.mark.parametrize("entity", entity_cov, ids=lambda x: x.name)
 @pytest.mark.parametrize("measure", measures_cov, ids=lambda x: x)
 @pytest.mark.parametrize("location", locations_cov)
-@pytest.mark.parametrize("year_id", [None, 2019, 1900, 'all'])
-def test_year_id_covariatelike(entity, measure, location, year_id):
-    check_year_in_data(entity, measure, location, year_id=year_id)
+@pytest.mark.parametrize("years", [None, 2019, 1900, 'all'])
+def test_year_id_covariatelike(entity, measure, location, years):
+    check_year_in_data(entity, measure, location, years=years)
 
 
 @pytest.mark.parametrize(
@@ -231,11 +231,11 @@ def test_core_population(measures):
 
 
 @pytest.mark.parametrize("measure", ["structure", "demographic_dimensions"])
-@pytest.mark.parametrize("year_id", [None, 2019, 1900, 'all'])
-def test_year_id_population(measure, year_id):
+@pytest.mark.parametrize("years", [None, 2019, 1900, 'all'])
+def test_year_id_population(measure, years):
     pop = ModelableEntity("ignored", "population", None)
     location = utility_data.get_location_id("India")
-    check_year_in_data(pop, measure, location, year_id=year_id)
+    check_year_in_data(pop, measure, location, years=years)
 
 
 # TODO - Underlying problem with gbd access. Remove when corrected.

--- a/tests/extract/test_core.py
+++ b/tests/extract/test_core.py
@@ -124,15 +124,6 @@ def test_year_id_causelike(entity, measure, location, year_id):
     measure_name, measure_id = measure
     if entity_expected_measure_ids & measure_id:
         check_year_in_data(entity_name, measure_name, location, year_id=year_id)
-        # if year_id != 1900:
-        #     df = core.get_data(entity_name, measure_name, location, year_id=year_id)
-        #     if year_id == None:
-        #         assert set(df.reset_index()["year_id"]) == set([2021])
-        #     elif year_id == 2019:
-        #         assert set(df.reset_index()["year_id"]) == set([2019])
-        # else:
-        #     with pytest.raises(ValueError, match="year_id must be one of"):
-        #         df = core.get_data(entity_name, measure_name, location, year_id=year_id)
 
 
 class MRFlag(IntFlag):
@@ -199,15 +190,6 @@ def test_year_id_risklike(entity, measure, location, year_id):
     measure_name, measure_id = measure
     if entity_expected_measure_ids & measure_id:
         check_year_in_data(entity_name, measure_name, location, year_id=year_id)
-        # if year_id != 1900:
-        #     df = core.get_data(entity_name, measure_name, location, year_id=year_id)
-        #     if year_id == None:
-        #         assert set(df.reset_index()["year_id"]) == set([2021])
-        #     elif year_id == 2019:
-        #         assert set(df.reset_index()["year_id"]) == set([2019])
-        # else:
-        #     with pytest.raises(ValueError, match="year_id must be one of"):
-        #         df = core.get_data(entity_name, measure_name, location, year_id=year_id)
 
 
 entity_cov = [
@@ -230,15 +212,6 @@ def test_core_covariatelike(entity, measure, location):
 @pytest.mark.parametrize("year_id", [None, 2019, 1900])
 def test_year_id_covariatelike(entity, measure, location, year_id):
     check_year_in_data(entity, measure, location, year_id=year_id)
-    # if year_id == None:
-    #     df = core.get_data(entity, measure, location, year_id=year_id)
-    #     assert set(df.reset_index()["year_id"]) == set([2021])
-    # elif year_id == 2019:
-    #     df = core.get_data(entity, measure, location, year_id=year_id)
-    #     assert set(df.reset_index()["year_id"]) == set([2019])
-    # else:
-    #     with pytest.raises(ValueError, match="year_id must be one of"):
-    #         df = core.get_data(entity, measure, location, year_id=year_id)
 
 
 @pytest.mark.parametrize(
@@ -261,21 +234,6 @@ def test_year_id_population(measure, year_id):
     pop = ModelableEntity("ignored", "population", None)
     location = utility_data.get_location_id("India")
     check_year_in_data(pop, measure, location, year_id=year_id)
-    # if year_id == None:
-    #     df = core.get_data(
-    #         pop, measures, utility_data.get_location_id("India"), year_id=year_id
-    #     )
-    #     assert set(df.reset_index()["year_id"]) == set([2021])
-    # elif year_id == 2019:
-    #     df = core.get_data(
-    #         pop, measures, utility_data.get_location_id("India"), year_id=year_id
-    #     )
-    #     assert set(df.reset_index()["year_id"]) == set([2019])
-    # elif year_id == 1900:
-    #     with pytest.raises(ValueError, match="year_id must be one of"):
-    #         df = core.get_data(
-    #             pop, measures, utility_data.get_location_id("India"), year_id=year_id
-    #         )
 
 
 # TODO - Underlying problem with gbd access. Remove when corrected.

--- a/tests/extract/test_core.py
+++ b/tests/extract/test_core.py
@@ -118,7 +118,7 @@ def test_core_years_causelike(entity, measure, location, year_id):
             elif year_id == 2019:
                 assert set(df.reset_index()['year_id']) == set([2019])
         else:
-            with pytest.raises(ValueError, match='expected to contain years'):
+            with pytest.raises(ValueError, match='year_id must be one of'):
                 df = core.get_data(entity_name, measure_name, location, year_id=year_id)
 
 
@@ -192,7 +192,7 @@ def test_core_years_risklike(entity, measure, location, year_id):
             elif year_id == 2019:
                 assert set(df.reset_index()['year_id']) == set([2019])
         else:
-            with pytest.raises(ValueError, match='expected to contain years'):
+            with pytest.raises(ValueError, match='year_id must be one of'):
                 df = core.get_data(entity_name, measure_name, location, year_id=year_id)
 
 
@@ -213,14 +213,16 @@ def test_core_covariatelike(entity, measure, location):
 @pytest.mark.parametrize("entity", entity_cov, ids=lambda x: x.name)
 @pytest.mark.parametrize("measure", measures_cov, ids=lambda x: x)
 @pytest.mark.parametrize("location", locations_cov)
+@pytest.mark.parametrize("year_id", [None, 2019, 1900])
 def test_core_years_covariatelike(entity, measure, location, year_id):
-    df = core.get_data(entity, measure, location, year_id=year_id)
     if year_id == None:
+        df = core.get_data(entity, measure, location, year_id=year_id)
         assert set(df.reset_index()['year_id']) == set([2021])
     elif year_id == 2019:
+        df = core.get_data(entity, measure, location, year_id=year_id)
         assert set(df.reset_index()['year_id']) == set([2019])
-    elif year_id == 1900:
-        with pytest.raises(ValueError, match='expected to contain years'):
+    else:
+        with pytest.raises(ValueError, match='year_id must be one of'):
             df = core.get_data(entity, measure, location, year_id=year_id)
 
 
@@ -242,13 +244,14 @@ def test_core_population(measures):
 @pytest.mark.parametrize("year_id", [None, 2019, 1900])
 def test_core_years_population(measures, year_id):
     pop = ModelableEntity("ignored", "population", None)
-    df = core.get_data(pop, measures, utility_data.get_location_id("India"), year_id=year_id)
     if year_id == None:
+        df = core.get_data(pop, measures, utility_data.get_location_id("India"), year_id=year_id)
         assert set(df.reset_index()['year_id']) == set([2021])
     elif year_id == 2019:
+        df = core.get_data(pop, measures, utility_data.get_location_id("India"), year_id=year_id)
         assert set(df.reset_index()['year_id']) == set([2019])
     elif year_id == 1900:
-        with pytest.raises(ValueError, match='expected to contain years'):
+        with pytest.raises(ValueError, match='year_id must be one of'):
             df = core.get_data(pop, measures, utility_data.get_location_id("India"), year_id=year_id)
 
 
@@ -296,11 +299,6 @@ def test_pulling_multiple_locations(entity, measure, locations):
     df = tester(entity_name, measure_name, locations)
 
 
-@pytest.mark.parametrize("year_id", [2019, 1900])
-def test_year_args_checks(year_id):
-    if year_id == 2019:
-        with pytest.raises(Exception, match='cannot provide a year ID and set get_all_years to True'):
-            df = core.get_data('measles', 'incidence_rate', 'India', get_all_years=True, year_id=year_id)
-    if year_id == 1900:
-        with pytest.raises(Exception, match='year_id must be one of'):
-            df = core.get_data('measles', 'incidence_rate', 'India', year_id=year_id)
+def test_year_args_compatibility():
+    with pytest.raises(Exception, match='cannot provide a year ID and set get_all_years to True'):
+        df = core.get_data(causes.measles, 'incidence_rate', 'India', get_all_years=True, year_id=2021)

--- a/tests/extract/test_core.py
+++ b/tests/extract/test_core.py
@@ -32,8 +32,8 @@ def check_year_in_data(entity, measure, location, years):
             assert set(df.reset_index()["year_id"]) == set([2021])
         elif years == 2019:
             assert set(df.reset_index()["year_id"]) == set([2019])
-        elif years == 'all':
-            assert set(df.reset_index()["year_id"]) == set(range(1990,2023))
+        elif years == "all":
+            assert set(df.reset_index()["year_id"]) == set(range(1990, 2023))
     else:
         with pytest.raises(ValueError, match="years must be in"):
             df = core.get_data(entity, measure, location, years=years)
@@ -120,7 +120,7 @@ def test_core_causelike(entity, measure, location):
 @pytest.mark.parametrize("entity", entity, ids=lambda x: x[0].name)
 @pytest.mark.parametrize("measure", measures, ids=lambda x: x[0])
 @pytest.mark.parametrize("location", locations)
-@pytest.mark.parametrize("years", [None, 2019, 1900, 'all'])
+@pytest.mark.parametrize("years", [None, 2019, 1900, "all"])
 def test_year_id_causelike(entity, measure, location, years):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
@@ -186,7 +186,7 @@ def test_core_risklike(entity, measure, location):
 @pytest.mark.parametrize("entity", entity_r, ids=lambda x: x[0].name)
 @pytest.mark.parametrize("measure", measures_r, ids=lambda x: x[0])
 @pytest.mark.parametrize("location", locations_r)
-@pytest.mark.parametrize("years", [None, 2019, 1900, 'all'])
+@pytest.mark.parametrize("years", [None, 2019, 1900, "all"])
 def test_year_id_risklike(entity, measure, location, years):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
@@ -211,7 +211,7 @@ def test_core_covariatelike(entity, measure, location):
 @pytest.mark.parametrize("entity", entity_cov, ids=lambda x: x.name)
 @pytest.mark.parametrize("measure", measures_cov, ids=lambda x: x)
 @pytest.mark.parametrize("location", locations_cov)
-@pytest.mark.parametrize("years", [None, 2019, 1900, 'all'])
+@pytest.mark.parametrize("years", [None, 2019, 1900, "all"])
 def test_year_id_covariatelike(entity, measure, location, years):
     check_year_in_data(entity, measure, location, years=years)
 
@@ -231,7 +231,7 @@ def test_core_population(measures):
 
 
 @pytest.mark.parametrize("measure", ["structure", "demographic_dimensions"])
-@pytest.mark.parametrize("years", [None, 2019, 1900, 'all'])
+@pytest.mark.parametrize("years", [None, 2019, 1900, "all"])
 def test_year_id_population(measure, years):
     pop = ModelableEntity("ignored", "population", None)
     location = utility_data.get_location_id("India")
@@ -280,4 +280,3 @@ def test_pulling_multiple_locations(entity, measure, locations):
     measure_name, measure_id = measure
     tester = success_expected if (entity_expected_measure_ids & measure_id) else fail_expected
     df = tester(entity_name, measure_name, locations)
-

--- a/tests/extract/test_core.py
+++ b/tests/extract/test_core.py
@@ -32,7 +32,7 @@ def check_year_in_data(entity, measure, location, year_id):
             assert set(df.reset_index()["year_id"]) == set([2021])
         elif year_id == 2019:
             assert set(df.reset_index()["year_id"]) == set([2019])
-    else:
+    else: # assumes that year_id is out of range if not 2019
         with pytest.raises(ValueError, match="year_id must be one of"):
             df = core.get_data(entity, measure, location, year_id=year_id)
 

--- a/tests/extract/test_core.py
+++ b/tests/extract/test_core.py
@@ -107,7 +107,7 @@ def test_core_causelike(entity, measure, location):
 @pytest.mark.parametrize("measure", measures, ids=lambda x: x[0])
 @pytest.mark.parametrize("location", locations)
 @pytest.mark.parametrize("year_id", [None, 2019, 1900])
-def test_core_years_causelike(entity, measure, location, year_id):
+def test_year_id_causelike(entity, measure, location, year_id):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
     if (entity_expected_measure_ids & measure_id):
@@ -181,7 +181,7 @@ def test_core_risklike(entity, measure, location):
 @pytest.mark.parametrize("measure", measures_r, ids=lambda x: x[0])
 @pytest.mark.parametrize("location", locations_r)
 @pytest.mark.parametrize("year_id", [None, 2019, 1900])
-def test_core_years_risklike(entity, measure, location, year_id):
+def test_year_id_risklike(entity, measure, location, year_id):
     entity_name, entity_expected_measure_ids = entity
     measure_name, measure_id = measure
     if (entity_expected_measure_ids & measure_id):
@@ -214,7 +214,7 @@ def test_core_covariatelike(entity, measure, location):
 @pytest.mark.parametrize("measure", measures_cov, ids=lambda x: x)
 @pytest.mark.parametrize("location", locations_cov)
 @pytest.mark.parametrize("year_id", [None, 2019, 1900])
-def test_core_years_covariatelike(entity, measure, location, year_id):
+def test_year_id_covariatelike(entity, measure, location, year_id):
     if year_id == None:
         df = core.get_data(entity, measure, location, year_id=year_id)
         assert set(df.reset_index()['year_id']) == set([2021])
@@ -242,7 +242,7 @@ def test_core_population(measures):
 
 @pytest.mark.parametrize("measures", ["structure", "demographic_dimensions"])
 @pytest.mark.parametrize("year_id", [None, 2019, 1900])
-def test_core_years_population(measures, year_id):
+def test_year_id_population(measures, year_id):
     pop = ModelableEntity("ignored", "population", None)
     if year_id == None:
         df = core.get_data(pop, measures, utility_data.get_location_id("India"), year_id=year_id)

--- a/tests/extract/test_core.py
+++ b/tests/extract/test_core.py
@@ -26,6 +26,7 @@ def fail_expected(entity_name, measure_name, location):
 
 
 def check_year_in_data(entity, measure, location, years):
+    # years expected to be 1900, 2019, None, or "all"
     if years != 1900:
         df = core.get_data(entity, measure, location, years=years)
         if years == None:

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -88,17 +88,6 @@ def test_extract_causelike(entity, measure, location):
     df = tester(entity_name, measure_name, utility_data.get_location_id(location))
 
 
-# @pytest.mark.parametrize("entity", entity, ids=lambda x: x[0].name)
-# @pytest.mark.parametrize("measure", measures, ids=lambda x: x[0])
-# @pytest.mark.parametrize("location", locations)
-# @pytest.mark.parametrize("year_id", [None, 2019, 1900])
-# def test_extract_years_causelike(entity, measure, location):
-#     entity_name, entity_expected_measure_ids = entity
-#     measure_name, measure_id = measure
-#     if (entity_expected_measure_ids & measure_id):
-#     df = tester(entity_name, measure_name, utility_data.get_location_id(location))
-
-
 class MRFlag(IntFlag):
     """
     Use the idea of a bit field with support from python's enum type IntFlag

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -88,6 +88,17 @@ def test_extract_causelike(entity, measure, location):
     df = tester(entity_name, measure_name, utility_data.get_location_id(location))
 
 
+# @pytest.mark.parametrize("entity", entity, ids=lambda x: x[0].name)
+# @pytest.mark.parametrize("measure", measures, ids=lambda x: x[0])
+# @pytest.mark.parametrize("location", locations)
+# @pytest.mark.parametrize("year_id", [None, 2019, 1900])
+# def test_extract_years_causelike(entity, measure, location):
+#     entity_name, entity_expected_measure_ids = entity
+#     measure_name, measure_id = measure
+#     if (entity_expected_measure_ids & measure_id):
+#     df = tester(entity_name, measure_name, utility_data.get_location_id(location))
+
+
 class MRFlag(IntFlag):
     """
     Use the idea of a bit field with support from python's enum type IntFlag


### PR DESCRIPTION
## add year ID option to vivarium inputs

### Description
- *Category*: feature
- *JIRA issue*: [MIC-4950](https://jira.ihme.washington.edu/browse/MIC-4950)

### Changes and notes
Add option to specify year ID to vivarium inputs interface calls.

### Testing
Called core.get_data functions for all measures with year ID. 
