### PR TITLE
disability weight year processing bugfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**5.0.3 - 07/12/24**
+
+ - Fix bug in processing year ID of disability weight
+
 **5.0.2 - 07/01/24**
 
  - Fix bug in validation of the year parameter

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -249,7 +249,9 @@ def extract_disability_weight(
             data["key"] = 1
             year_df["key"] = 1
             # Merge to get the Cartesian product, then drop the key column
-            data = pd.merge(data, year_df, on="key").drop("key", axis=1)
+            data = pd.merge(data.drop("year_id", axis=1), year_df, on="key").drop(
+                "key", axis=1
+            )
         else:
             data["year_id"] = year_id
     return data


### PR DESCRIPTION
## disability weight year processing bugfix

### Description
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ

### Changes and notes
Remove duplicate year_id column when merging.

### Testing
Pulled disability weights for measles.
