### PR TITLE
disability weight location processing bugfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**5.0.4 - 07/16/24**
+
+ - Fix bug in processing locations when pulling disability weights
+
 **5.0.3 - 07/12/24**
 
  - Fix bug in processing year ID of disability weight
@@ -13,7 +17,7 @@
 **5.0.0 - 05/20/24**
 
  - Pull GBD 2021 data
- - Add functionality to pull multiple locationals at once
+ - Add functionality to pull multiple locations at once
 
 **4.1.4 - 01/11/24**
 

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -240,9 +240,8 @@ def extract_disability_weight(
             data["key"] = 1
             year_df["key"] = 1
             # Merge to get the Cartesian product, then drop the key column
-            data = pd.merge(
-                data.drop("year_id", axis=1, errors="ignore"), year_df, on="key"
-            ).drop("key", axis=1)
+            data = data.drop("year_id", axis=1) if "year_id" in data.columns else data
+            data = pd.merge(data, year_df, on="key").drop("key", axis=1)
         else:
             data["year_id"] = year_id
     return data

--- a/src/vivarium_inputs/extract.py
+++ b/src/vivarium_inputs/extract.py
@@ -229,18 +229,9 @@ def extract_disability_weight(
         "all",
         location_id,
     )
-    disability_data = disability_weights.loc[
+    data = disability_weights.loc[
         disability_weights.healthstate_id == entity.healthstate.gbd_id, :
     ]
-    # Update location_id to match original location id
-    # Note: The flat file we read data from in gbd.get_auxiliary_data only has location_id 1
-    # because disability weights are the same for all locations
-    data = []
-    for loc_id in location_id:
-        loc_data = disability_data.copy()
-        loc_data["location_id"] = loc_id
-        data.append(loc_data)
-    data = pd.concat(data)
     if year_id:  # if not pulling all years
         if isinstance(year_id, list):
             # Create a DataFrame from your year_ids
@@ -249,9 +240,9 @@ def extract_disability_weight(
             data["key"] = 1
             year_df["key"] = 1
             # Merge to get the Cartesian product, then drop the key column
-            data = pd.merge(data.drop("year_id", axis=1), year_df, on="key").drop(
-                "key", axis=1
-            )
+            data = pd.merge(
+                data.drop("year_id", axis=1, errors="ignore"), year_df, on="key"
+            ).drop("key", axis=1)
         else:
             data["year_id"] = year_id
     return data


### PR DESCRIPTION
## disability weight location processing bugfix

### Description=
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5171

### Changes and notes
Don't duplicate data for locations since this is already done in gbd access.
Only drop year_id column if it is present in data.

### Testing
Pulled disability weight for diarrheal diseases with no year specified, for 2021, for 2019 and 2021, and for all years.