### PR TITLE
don't install dependencies inside package directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,13 +51,6 @@ jobs:
           else
             echo "upstream_vivarium_exist=false" >> $GITHUB_ENV
           fi
-      - name: check for upstream vivarium_public_health
-        run: |
-          if git ls-remote --exit-code --heads https://github.com/ihmeuw/vivarium_public_health.git ${branch_name} == "0"; then
-            echo "upstream_vivarium_public_health_exist=true" >> $GITHUB_ENV
-          else
-            echo "upstream_vivarium_public_health_exist=false" >> $GITHUB_ENV
-          fi
       - name: check for upstream gbd_mapping
         run: |
           if git ls-remote --exit-code --heads https://github.com/ihmeuw/gbd_mapping.git ${branch_name} == "0"; then
@@ -74,27 +67,20 @@ jobs:
         if: env.upstream_vivarium_exist == 'true'
         run: |
           echo "Cloning vivarium upstream branch: ${branch_name}"
+          pushd ..
           git clone --branch=${branch_name} https://github.com/ihmeuw/vivarium.git
           pushd vivarium
           pip install .
-          popd
-      - name: Retrieve upstream vivarium_public_health
-        if: env.upstream_vivarium_public_health_exist == 'true'
-        run: |
-          echo "Cloning vivarium_public_health upstream branch: ${branch_name}"
-          git clone --branch=${branch_name} https://github.com/ihmeuw/vivarium_public_health.git
-          pushd vivarium_public_health
-          pip install .
-          popd
+          popd && popd
       - name: Retrieve upstream gbd_mapping
         if: env.upstream_gbd_mapping_exist == 'true'
         run: |
           echo "Cloning upstream gbd_mapping branch: ${branch_name}"
+          pushd ..
           git clone --branch=${branch_name} https://github.com/ihmeuw/gbd_mapping.git
           pushd gbd_mapping
           pip install .
-          popd
-
+          popd && popd
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip        

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**5.0.4 - 08/02/24**
+
+ - Fix CI bug when installing upstream dependencies
+
 **5.0.4 - 07/16/24**
 
  - Fix bug in processing locations when pulling disability weights

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**5.0.4 - 08/02/24**
+**5.0.5 - 08/02/24**
 
  - Fix CI bug when installing upstream dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,6 @@
 [tool.black]
 line_length = 94
-exclude = '''
-/(
-   vivarium
-   | vivarium_public_health
-   | gbd_mapping
-)/
-
-'''
 
 [tool.isort]
 profile = "black"
-skip = ["vivarium", "vivarium_public_health", "gbd_mapping"]
 known_third_party = ["vivarium", "vivarium_public_health", "gbd_mapping"]


### PR DESCRIPTION
## Don't install dependencies inside package directory
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: CI/infrastructure
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5209

### Changes and notes
-  Don't install dependencies inside package directory
- VPH isn't actually a dependency, so don't install it

### Testing
CI works as expected with upstream branches