### PR TITLE
Set up e2e CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,35 +152,31 @@ pipeline {
               }
             }
 
-            // Quality Checks
-            stage("Format") {
-              steps {
-                sh "${ACTIVATE} && make format"
-              }
-            }
-
-            // stage("Lint") {
-            //   steps {
-            //     sh "${ACTIVATE} && make lint"
-            //   }
-            // }
+            // NOTE: we exclude several usual stages (Format, Lint, and Type Check)
+            // because they are already being run in github actions
 
             // Tests
-            // removable, if passwords can be exported to env. securely without bash indirection
-            // stage("Run Integration Tests") {
-            //   steps {
-            //     sh "${ACTIVATE} && make integration"
-            //     publishHTML([
-            //       allowMissing: true,
-            //       alwaysLinkToLastBuild: false,
-            //       keepAll: true,
-            //       reportDir: "output/htmlcov_integration",
-            //       reportFiles: "index.html",
-            //       reportName: "Coverage Report - Integration tests",
-            //       reportTitles: ''
-            //     ])
-            //   }
-            // }
+            // NOTE: we only run slow e2e tests here because unit and mocked e2e tests are already 
+            // being run in github actions
+            // NOTE: we do not distinguish between scheduled (IS_CRON) and other (e.g. on-push)
+            // builds here like we typically. Usually we would run slow tests on a schedule and
+            // fast tests otherwise, but in this case the repo (hosted on github) does not have
+            // access to the Jenkins builds anyway and so we simply run slow tests always
+            // and will at least get the slack message upon failure.
+            stage("Run Unmocked E2E Tests") {
+              steps {
+                sh "${ACTIVATE} && make e2e-runslow"
+                publishHTML([
+                  allowMissing: true,
+                  alwaysLinkToLastBuild: false,
+                  keepAll: true,
+                  reportDir: "output/htmlcov_e2e",
+                  reportFiles: "index.html",
+                  reportName: "Coverage Report - E2E tests",
+                  reportTitles: ''
+                ])
+              }
+            }
 
             // Build
             stage('Build and Deploy') {

--- a/Makefile
+++ b/Makefile
@@ -55,12 +55,6 @@ build-env: # Make a new conda environment
 	conda create ${CONDA_ENV_CREATION_FLAG} python=${PYTHON_VERSION} --yes
 
 install: # Install setuptools, install this package in editable mode
-# NOTE: we cannot currently install anything but the 'main' branch in vivarium_gbd_access
-# due to that being hosted on bitbucket and behind the IHME firewall. One workaround until
-# we get this fixed is to TEMPORARILY (i.e. just for testing) change the vivarium_gbd_access 
-# setup.py data_requires value to install the develop branch of interest:
-# "vivarium-gbd-access @ git+ssh://git@stash.ihme.washington.edu:7999/sims/vivarium_gbd_access.git@BRANCH-TO-INSTALL#egg=vivarium-gbd-access"
-# Don't forget to change it back before merging!
 	pip install --upgrade pip setuptools
 	pip install -e .[DEV]
 	@cd ..
@@ -78,6 +72,17 @@ install: # Install setuptools, install this package in editable mode
 	@echo "----------------------------------------"
 	@sh vivarium_build_utils/install_dependency_branch.sh vivarium ${GIT_BRANCH} jenkins
 	@sh vivarium_build_utils/install_dependency_branch.sh gbd_mapping ${GIT_BRANCH} jenkins
+# FIXME: Add support for installing non-develop branches of vivarium_gbd_access
+# @sh vivarium_build_utils/install_dependency_branch.sh vivarium_gbd_access ${GIT_BRANCH} jenkins
+
+# NOTE: we cannot currently install anything but the 'main' branch in vivarium_gbd_access
+# due to it being hosted on bitbucket and behind the IHME firewall (which vivarium_build_utils 
+# cannot see because it is on github). One workaround until we get this fixed is to 
+# TEMPORARILY (i.e. just for testing) change the vivarium_gbd_access setup.py data_requires 
+# value to install the branch of interest:
+# "vivarium-gbd-access @ git+ssh://git@stash.ihme.washington.edu:7999/sims/vivarium_gbd_access.git@BRANCH-TO-INSTALL#egg=vivarium-gbd-access"
+# Then, assuming the build passes, you can change it back (which will cause builds to 
+# start failing again until everything gets merged to main).
 
 e2e-runslow: $(MAKE_SOURCES) # Run all (--runslow) end-to-end tests
 	export COVERAGE_FILE=./output/.coverage.e2e

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ build-env: # Make a new conda environment
 	conda create ${CONDA_ENV_CREATION_FLAG} python=${PYTHON_VERSION} --yes
 
 install: # Install setuptools, install this package in editable mode
+# NOTE: we cannot currently install anything but the 'main' branch in vivarium_gbd_access
+# due to that being hosted on bitbucket and behind the IHME firewall. One workaround until
+# we get this fixed is to TEMPORARILY (i.e. just for testing) change the vivarium_gbd_access 
+# setup.py data_requires value to install the develop branch of interest:
+# "vivarium-gbd-access @ git+ssh://git@stash.ihme.washington.edu:7999/sims/vivarium_gbd_access.git@BRANCH-TO-INSTALL#egg=vivarium-gbd-access"
+# Don't forget to change it back before merging!
 	pip install --upgrade pip setuptools
 	pip install -e .[DEV]
 	@cd ..
@@ -73,21 +79,9 @@ install: # Install setuptools, install this package in editable mode
 	@sh vivarium_build_utils/install_dependency_branch.sh vivarium ${GIT_BRANCH} jenkins
 	@sh vivarium_build_utils/install_dependency_branch.sh gbd_mapping ${GIT_BRANCH} jenkins
 
-
-
-format: setup.py pyproject.toml $(MAKE_SOURCES) # Run the code formatter and import sorter
-	black $(LOCATIONS)
-	isort $(LOCATIONS)
-	@echo "Ignore, Created by Makefile, `date`" > $@
-
-lint: .flake8 .bandit $(MAKE_SOURCES) # Run the code linter and package security vulnerability checker
-	-flake8 $(LOCATIONS)
-	-safety check
-	@echo "Ignore, Created by Makefile, `date`" > $@
-
-integration: $(MAKE_SOURCES) # Run the end-to-end tests
-	export COVERAGE_FILE=./output/.coverage.integration
-	pytest --runslow tests --cov --cov-report term --cov-report html:./output/htmlcov_integration
+e2e-runslow: $(MAKE_SOURCES) # Run all (--runslow) end-to-end tests
+	export COVERAGE_FILE=./output/.coverage.e2e
+	pytest tests/e2e -vvv --runslow --cov --cov-report term --cov-report html:./output/htmlcov_e2e
 	@echo "Ignore, Created by Makefile, `date`" > $@
 
 build-doc: $(MAKE_SOURCES) # Build the Sphinx docs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ def pytest_collection_modifyitems(config, items):
 
 @pytest.fixture
 def runslow(request: pytest.FixtureRequest):
+    """Fixture to allow 'runslow' to be used as an argument in tests."""
     return request.config.getoption("--runslow")
 
 

--- a/tests/e2e/test_get_measure.py
+++ b/tests/e2e/test_get_measure.py
@@ -201,7 +201,7 @@ MEASURES_R = [
 ]
 
 
-@pytest.mark.skip("TODO: [mic-5407]")
+@pytest.mark.skip("TODO: [mic-5456]")
 @pytest.mark.parametrize("entity_details", ENTITIES_R, ids=lambda x: x[0].name)
 @pytest.mark.parametrize("measure", MEASURES_R, ids=lambda x: x[0])
 def test_get_measure_risklike(entity_details, measure):
@@ -216,7 +216,7 @@ ENTITIES_COV = [
 MEASURES_COV = ["estimate"]
 
 
-@pytest.mark.skip("TODO: [mic-5407]")
+@pytest.mark.skip("TODO: [mic-5456]")
 @pytest.mark.parametrize("entity", ENTITIES_COV, ids=lambda x: x.name)
 @pytest.mark.parametrize("measure", MEASURES_COV, ids=lambda x: x)
 def test_get_measure_covariatelike(entity, measure):
@@ -230,7 +230,7 @@ ENTITIES_R = [
 MEASURES_R = ["relative_risk"]
 
 
-@pytest.mark.skip("TODO: [mic-5407]")
+@pytest.mark.skip("TODO: [mic-5456]")
 @pytest.mark.parametrize("entity_details", ENTITIES_R, ids=lambda x: x[0].name)
 @pytest.mark.parametrize("measure", MEASURES_R, ids=lambda x: x[0])
 def test_get_failing_relative_risk(entity_details, measure):
@@ -245,7 +245,7 @@ ENTITIES_R = [
 MEASURES_R = ["relative_risk"]
 
 
-@pytest.mark.skip("TODO: [mic-5407]")
+@pytest.mark.skip("TODO: [mic-5456]")
 @pytest.mark.parametrize("entity_details", ENTITIES_R, ids=lambda x: x[0].name)
 @pytest.mark.parametrize("measure", MEASURES_R, ids=lambda x: x[0])
 def test_get_working_relative_risk(entity_details, measure):

--- a/tests/e2e/test_get_measure.py
+++ b/tests/e2e/test_get_measure.py
@@ -94,7 +94,6 @@ CAUSE_MEASURES = [
 ]
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("entity_details", CAUSES, ids=lambda x: x[0].name)
 @pytest.mark.parametrize("measure", CAUSE_MEASURES, ids=lambda x: x)
 @pytest.mark.parametrize(
@@ -106,6 +105,7 @@ def test_get_measure_causelike(
     measure: str,
     data_type: str | list[str],
     mock_gbd: bool,
+    runslow: bool,
     mocker: MockerFixture,
 ):
     # Test-specific fixme skips
@@ -121,7 +121,7 @@ def test_get_measure_causelike(
     ]
     is_unimplemented = isinstance(data_type, list) or is_unimplemented_means
 
-    run_test(entity_details, measure, data_type, mock_gbd, mocker, is_unimplemented)
+    run_test(entity_details, measure, data_type, mock_gbd, runslow, mocker, is_unimplemented)
 
 
 SEQUELAE = [
@@ -155,6 +155,7 @@ def test_get_measure_sequelalike(
     measure: str,
     data_type: str | list[str],
     mock_gbd: bool,
+    runslow: bool,
     mocker: MockerFixture,
 ):
 
@@ -168,7 +169,7 @@ def test_get_measure_sequelalike(
     ]
     is_unimplemented = isinstance(data_type, list) or is_unimplemented_means
 
-    run_test(entity_details, measure, data_type, mock_gbd, mocker, is_unimplemented)
+    run_test(entity_details, measure, data_type, mock_gbd, runslow, mocker, is_unimplemented)
 
 
 ENTITIES_R = [
@@ -262,13 +263,16 @@ def run_test(
     measure: str,
     data_type: str | list[str],
     mock_gbd: bool,
+    runslow: bool,
     mocker: MockerFixture,
     is_unimplemented: bool,
 ):
     entity, entity_expected_measures = entity_details
 
+    if not runslow and not mock_gbd:
+        pytest.skip("Need --runslow option to run unmocked tests")
     if NO_GBD_ACCESS and not mock_gbd:
-        pytest.skip("Need GBD access to run this test")
+        pytest.skip("Need GBD access to run unmocked tests")
 
     tester = success_expected if measure in entity_expected_measures else fail_expected
     if is_unimplemented:


### PR DESCRIPTION
## Set up end-to-end CI
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> test
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5455

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This runs the slow/unmocked e2e tests on Jenkins. We currently have
both on-push pipeline and a scheduled/nightly pipeline. Typically we
wouldn't run slow tests on-push, but in this case we can't block
a github repo merge due to a failing jenkins pipeline anyway, so we figured
might as well just do it on every push and at least get the slack message late.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Unfortunately, we don't currently have a way to have github see an upstream
bitbucket dependency - this is exactly what's required here b/c this branch
requires a non-main (i.e. unreleased) branch in vivarium_gbd_access. So the
builds are failing.

However, I did test that this works by temporarily modifying this repo's setup.py
to install the required vivarium-gbd-access branch and then pushed that. 

![image](https://github.com/user-attachments/assets/84d810a3-eae9-4332-b498-5f0c2e4286b3)

